### PR TITLE
fix: prevent sidebar flyout style carryover

### DIFF
--- a/static/js/preview.js
+++ b/static/js/preview.js
@@ -343,6 +343,7 @@
     flyout.classList.remove("collapse", "show", "collapsing");
     flyout.classList.add("sidebar-menu-flyout");
     flyout.setAttribute("data-moo-sidebar-flyout", "");
+    flyout.removeAttribute("style");
     flyout.style.setProperty("--moo-sidebar-flyout-block-start", `${Math.round(rect.top)}px`);
     flyout.style.setProperty("--moo-sidebar-flyout-inline-start", `${Math.round(inlineStart)}px`);
 

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -726,6 +726,7 @@ class SidebarTests(CatalogTestCase):
         self.assertIn('window.addEventListener("click"', script)
         self.assertIn("cloneNode(true)", script)
         self.assertIn("sidebar-menu-flyout", script)
+        self.assertIn('flyout.removeAttribute("style")', script)
         self.assertIn("sidebarFlyoutOwner === item", script)
         self.assertIn("data-moo-sidebar-flyout", script)
         self.assertIn("sidebar-menu-item--flyout-open", script)


### PR DESCRIPTION
## Summary
- Clear copied inline styles from collapsed sidebar flyout clones before positioning them
- Add a regression assertion for the flyout clone behavior

## Tests
- `.venv/bin/python -m unittest tests.test_sidebar -v`
- `.venv/bin/python -m unittest discover -s tests -v`
- `git diff --check`