### PR TITLE
Polish homepage product message

### DIFF
--- a/scss/catalog.scss
+++ b/scss/catalog.scss
@@ -309,6 +309,147 @@ body {
   max-width: 44rem;
 }
 
+.moo-catalog__home-hero {
+  display: grid;
+  gap: 2rem;
+}
+
+.moo-catalog__home-hero-grid {
+  display: grid;
+  align-items: center;
+  gap: 2rem;
+}
+
+.moo-catalog__home-visual {
+  overflow: hidden;
+  border: var(--bs-border-width) solid var(--moo-border);
+  border-radius: var(--bs-border-radius-lg);
+  background: var(--bs-body-bg);
+  box-shadow: var(--bs-box-shadow-sm);
+}
+
+.moo-catalog__home-visual-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 3 / 2;
+  object-fit: cover;
+}
+
+.moo-catalog__home-principles {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.moo-catalog__home-principle {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.moo-catalog__home-principle-icon {
+  display: inline-grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  color: var(--bs-body-color);
+  border: var(--bs-border-width) solid var(--moo-border);
+  border-radius: var(--bs-border-radius);
+  background: var(--bs-body-bg);
+}
+
+.moo-catalog__home-principle-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.moo-catalog__home-principle h2 {
+  margin-bottom: 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.moo-catalog__home-principle p {
+  margin-bottom: 0;
+  color: var(--bs-secondary-color);
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
+.moo-catalog__home-scroll {
+  display: grid;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.moo-catalog__home-scroll-header {
+  display: grid;
+  gap: 1rem;
+}
+
+.moo-catalog__home-scroll-track {
+  --scroll-fade-size: min(18%, 5rem);
+  display: flex;
+  gap: 1rem;
+  padding-block: 0.25rem 0.75rem;
+  scroll-snap-type: x proximity;
+}
+
+.moo-catalog__home-scroll-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 1rem;
+  width: unquote("min(22rem, 78vw)");
+  min-height: 8rem;
+  flex: 0 0 auto;
+  padding: 1rem;
+  color: var(--bs-body-color);
+  text-decoration: none;
+  border: var(--bs-border-width) solid var(--moo-border);
+  border-radius: var(--bs-border-radius-lg);
+  background: var(--bs-body-bg);
+  box-shadow: var(--bs-box-shadow-sm);
+  scroll-snap-align: start;
+}
+
+.moo-catalog__home-scroll-card:hover {
+  border-color: var(--bs-secondary-color);
+}
+
+.moo-catalog__home-scroll-icon {
+  display: inline-grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  place-items: center;
+  color: var(--bs-body-color);
+  border: var(--bs-border-width) solid var(--moo-border);
+  border-radius: var(--bs-border-radius);
+  background: var(--bs-tertiary-bg);
+}
+
+.moo-catalog__home-scroll-icon svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.moo-catalog__home-scroll-copy {
+  display: grid;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.moo-catalog__home-scroll-title {
+  font-weight: 600;
+}
+
+.moo-catalog__home-scroll-text {
+  color: var(--bs-secondary-color);
+  font-size: 0.9375rem;
+  line-height: 1.45;
+}
+
 .moo-catalog__component-list {
   margin-top: 4rem;
 }
@@ -438,6 +579,17 @@ body {
   .moo-catalog__toolbar {
     grid-template-columns: minmax(16rem, 1fr) 12rem auto;
     align-items: start;
+  }
+
+  .moo-catalog__home-scroll-header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+  }
+}
+
+@media (min-width: 992px) {
+  .moo-catalog__home-hero-grid {
+    grid-template-columns: minmax(0, 1.08fr) minmax(20rem, 0.92fr);
   }
 }
 

--- a/src/pages/index.html.jinja
+++ b/src/pages/index.html.jinja
@@ -6,11 +6,49 @@
 {% block title %}Moo UI{% endblock %}
 
 {% block content %}
-  <section class="moo-catalog__intro" aria-labelledby="home-title">
-    {{ typography("Moo UI", variant="page-title", id="home-title") }}
-    <p class="lead text-body-secondary mb-0">
-      A Bootstrap-native component system with a focused, modern visual language.
-    </p>
+  <section class="moo-catalog__home-hero" aria-labelledby="home-title">
+    <div class="moo-catalog__intro">
+      {{ typography("Moo UI", variant="page-title", id="home-title") }}
+      <p class="lead text-body-secondary mb-0">
+        Bootstrap-native components with a calm, modern shadcn-style feel.
+      </p>
+    </div>
+
+    <div class="moo-catalog__home-hero-grid">
+      <figure class="moo-catalog__home-visual mb-0">
+        <img
+          class="moo-catalog__home-visual-image"
+          src="{{ root_path }}assets/images/readme-hero.webp"
+          alt="A sketched Moo UI catalog showing Bootstrap markup with a modern interface feel"
+          width="1536"
+          height="1024"
+        >
+      </figure>
+
+      <div class="moo-catalog__home-principles" aria-label="Moo UI principles">
+        <section class="moo-catalog__home-principle">
+          <span class="moo-catalog__home-principle-icon" aria-hidden="true">{{ render_icon("layers", "inline-start") }}</span>
+          <div>
+            <h2>Bootstrap is the contract</h2>
+            <p>Keep Bootstrap markup, documented behavior, <code>data-bs-*</code> APIs, Sass knobs, and <code>--bs-*</code> variables.</p>
+          </div>
+        </section>
+        <section class="moo-catalog__home-principle">
+          <span class="moo-catalog__home-principle-icon" aria-hidden="true">{{ render_icon("sparkles", "inline-start") }}</span>
+          <div>
+            <h2>Shaped, not replaced</h2>
+            <p>Spacing, state language, radius, and contrast are tuned on top of Bootstrap instead of bolted on as a second framework.</p>
+          </div>
+        </section>
+        <section class="moo-catalog__home-principle">
+          <span class="moo-catalog__home-principle-icon" aria-hidden="true">{{ render_icon("code", "inline-start") }}</span>
+          <div>
+            <h2>HTML stays first-class</h2>
+            <p>Examples render from the same Jinja macros you copy, with no SPA runtime required to browse, build, or ship.</p>
+          </div>
+        </section>
+      </div>
+    </div>
   </section>
 
   <section class="moo-catalog__dashboard" aria-label="Get started">
@@ -49,6 +87,43 @@
           ) }}
         </div>
       {% endcall %}
+    </div>
+  </section>
+
+  <section class="moo-catalog__home-scroll" aria-labelledby="home-scroll-title">
+    <div class="moo-catalog__home-scroll-header">
+      <div>
+        <h2 class="h4 mb-2" id="home-scroll-title">Bootstrap primitives, modern shell</h2>
+        <p class="text-body-secondary mb-0">
+          A wide scan of the catalog: familiar Bootstrap surfaces, tuned into one quiet interface language.
+        </p>
+      </div>
+      {{ button(
+        "Browse catalog",
+        variant="outline",
+        size="sm",
+        element="a",
+        href=root_path ~ "components/index.html"
+      ) }}
+    </div>
+
+    <div class="moo-catalog__home-scroll-track scroll-fade-x no-scrollbar overflow-x-auto">
+      {% for item in [
+        ("Button", "Actions, icons, loading, and states", "button", "mouse-pointer-click"),
+        ("Popover", "Native Bootstrap overlay with tuned rhythm", "popover", "square-dashed-mouse-pointer"),
+        ("Sheet", "Offcanvas behavior with a calm side panel", "sheet", "panel-right"),
+        ("Field", "Form labels, help text, and validation", "field", "form"),
+        ("Sidebar", "Application shell patterns for portals", "sidebar", "panel-left"),
+        ("Toast", "Native notifications with clear hierarchy", "toast", "bell")
+      ] %}
+        <a class="moo-catalog__home-scroll-card" href="{{ root_path }}components/{{ item[2] }}.html">
+          <span class="moo-catalog__home-scroll-icon" aria-hidden="true">{{ render_icon(item[3], "inline-start") }}</span>
+          <span class="moo-catalog__home-scroll-copy">
+            <span class="moo-catalog__home-scroll-title">{{ item[0] }}</span>
+            <span class="moo-catalog__home-scroll-text">{{ item[1] }}</span>
+          </span>
+        </a>
+      {% endfor %}
     </div>
   </section>
 {% endblock %}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -299,8 +299,12 @@ class CatalogContractTests(CatalogTestCase):
         self.assertIn('data-moo-shell="catalog"', home)
         self.assertIn("Moo UI", home)
         self.assertIn(
-            "Bootstrap-native component system", home
+            "Bootstrap-native components with a calm, modern shadcn-style feel.",
+            home,
         )
+        self.assertIn("Bootstrap is the contract", home)
+        self.assertIn("Bootstrap primitives, modern shell", home)
+        self.assertIn("scroll-fade-x no-scrollbar overflow-x-auto", home)
         self.assertIn('href="components/index.html"', home)
         self.assertRegex(home, r'class="[^"]*\bbtn\b[^"]*\bbtn-outline')
 


### PR DESCRIPTION
## Summary
- Reworks the homepage hero to communicate the product message more directly.
- Adds a large bottom scroll-fade catalog strip inspired by the component browsing experience.
- Updates catalog tests for the new homepage copy and scroll-fade structure.

## Validation
- `.venv/bin/python -m unittest discover -s tests -q`
- `git diff --check --cached`