### PR TITLE
Fix release publish workflow dispatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -75,7 +75,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release notes
-        if: github.event_name != 'workflow_dispatch'
+        if: startsWith(github.ref_name, 'v')
         run: |
           tag="${GITHUB_REF_NAME}"
           if gh release view "${tag}" >/dev/null 2>&1; then

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -52,3 +52,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${tag}" -m "Release ${tag}"
           git push origin "${tag}"
+
+      - name: Dispatch npm publish workflow
+        if: steps.release_tag.outputs.exists == 'false'
+        run: gh workflow run npm-publish.yml --ref "${{ steps.package.outputs.tag }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Dispatch the npm publish workflow after the release-tag workflow creates a tag.
- Allow workflow-dispatched tag runs to create GitHub Release notes.

## Why
GitHub does not trigger normal downstream workflows from tag pushes made with the default GITHUB_TOKEN recursion guard. The tag workflow now explicitly uses workflow_dispatch for the publish workflow.

## Verification
- Inspected workflow diff.
- Confirmed @wpmoo/ui versions on npm: 0.1.0, 0.1.1, 0.2.0.
