### PR TITLE
Fix npm publish OIDC workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,7 +44,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22.14.0"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Check package version
         id: package


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` in npm-publish workflow
- The empty `NODE_AUTH_TOKEN` in `.npmrc` conflicted with OIDC trusted publishing, causing E404

## Test plan
- [x] Trusted publisher configured on npmjs.com for wpmoo-org/ui
- [ ] Re-trigger npm publish after merge to verify OIDC flow works