### PR TITLE
Fix npm OIDC publish: registry-only .npmrc

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           node-version: "22.14.0"
 
+      - name: Configure npm registry
+        run: echo "registry=https://registry.npmjs.org/" >> .npmrc
+
       - name: Check package version
         id: package
         run: |


### PR DESCRIPTION
npm needs the registry URL without an auth token for OIDC trusted publishing to work.