### PR TITLE
Upgrade npm for OIDC trusted publishing auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           node-version: "22.14.0"
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Configure npm registry
         run: echo "registry=https://registry.npmjs.org/" >> .npmrc
 


### PR DESCRIPTION
## Summary
- npm 10.x (shipped with Node 22.14.0) only supports OIDC for provenance signing, not registry authentication
- Upgrade to npm@latest (11.x) before publish to enable OIDC token exchange for trusted publishing
- Fixes persistent ENEEDAUTH error on `npm publish --provenance`

## Test plan
- [ ] CI passes (contract tests + build)
- [ ] After merge, re-dispatch npm-publish workflow to verify OIDC auth works