### PR TITLE
Use latest Node 22.x for npm 12 compatibility

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Node for npm
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "22.14.0"
 
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@11

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: "22"
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Configure npm registry
         run: echo "registry=https://registry.npmjs.org/" >> .npmrc

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           node-version: "22.14.0"
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Configure npm registry
         run: echo "registry=https://registry.npmjs.org/" >> .npmrc
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Node for npm
         uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "22"
 
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@latest


### PR DESCRIPTION
## Summary
- npm@12 requires Node ^22.22.2; pinned 22.14.0 caused EBADENGINE
- Use `node-version: "22"` to get latest 22.x LTS

## Test plan
- [ ] CI passes
- [ ] Re-dispatch npm-publish after merge