### PR TITLE
Fix release publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install -r requirements-dev.txt
 
+      - name: Install Playwright Chromium
+        run: python -m playwright install --with-deps chromium
+
       - name: Run contract tests
         run: python -m unittest discover -s tests -v
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:


### PR DESCRIPTION
Summary

Fix the release automation blockers found while publishing v0.5.0.

Changes:
- Install Playwright Chromium in npm-publish.yml before running the full test suite.
- Grant release-tag.yml the narrow actions: write permission needed to dispatch npm-publish.yml.

Scope:
- No version bump.
- No tag deletion, recreation, or manual tag push.
- Existing v0.5.0 tag remains untouched.

Verification:
- git diff --check: clean

After merge:
- Manually dispatch npm-publish.yml against existing v0.5.0.
- Verify @wpmoo/ui@0.5.0, npm latest, tag commit, and GitHub Release alignment.