### PR TITLE
Fix publishing existing release tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,13 +5,18 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Existing v* tag to publish while running the workflow definition from the selected branch
+        required: false
+        type: string
 
 permissions:
   contents: write
   id-token: write
 
 concurrency:
-  group: npm-publish-${{ github.ref }}
+  group: npm-publish-${{ inputs.release_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -25,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.release_ref || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -58,13 +64,22 @@ jobs:
 
       - name: Check package version
         id: package
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
           name="$(node -p "require('./package.json').name")"
           version="$(node -p "require('./package.json').version")"
-          tag="${GITHUB_REF_NAME}"
+          tag="${RELEASE_REF:-${GITHUB_REF_NAME}}"
+          source_commit="$(git rev-parse HEAD)"
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
-          if [ "${GITHUB_REF_TYPE}" != "tag" ]; then
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          if [ -n "${RELEASE_REF}" ]; then
+            if ! git show-ref --verify --quiet "refs/tags/${tag}"; then
+              echo "Release ref ${tag} must be an existing tag."
+              exit 1
+            fi
+          elif [ "${GITHUB_REF_TYPE}" != "tag" ]; then
             echo "Publish must run from a version tag, not ${GITHUB_REF_TYPE} ${tag}."
             exit 1
           fi
@@ -72,7 +87,7 @@ jobs:
             echo "Tag ${tag} does not match package version v${version}."
             exit 1
           fi
-          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+          if ! git merge-base --is-ancestor "${source_commit}" origin/main; then
             echo "Tag ${tag} does not point to a commit in origin/main history."
             exit 1
           fi
@@ -92,9 +107,9 @@ jobs:
         run: npm publish --access public --provenance
 
       - name: Create GitHub release notes
-        if: startsWith(github.ref_name, 'v')
+        if: startsWith(steps.package.outputs.tag, 'v')
         run: |
-          tag="${GITHUB_REF_NAME}"
+          tag="${{ steps.package.outputs.tag }}"
           if gh release view "${tag}" >/dev/null 2>&1; then
             echo "Release ${tag} already exists; skipping."
           else

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -256,15 +256,20 @@ for (const specifier of [
 
                 self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_publish_workflow_requires_a_matching_tag_ref(self) -> None:
+    def test_publish_workflow_requires_a_matching_existing_tag_ref(self) -> None:
         workflow = (ROOT / ".github/workflows/npm-publish.yml").read_text(
             encoding="utf-8"
         )
 
+        self.assertIn("release_ref:", workflow)
+        self.assertIn("ref: ${{ inputs.release_ref || github.ref }}", workflow)
+        self.assertIn('tag="${RELEASE_REF:-${GITHUB_REF_NAME}}"', workflow)
+        self.assertIn('git show-ref --verify --quiet "refs/tags/${tag}"', workflow)
         self.assertIn('${GITHUB_REF_TYPE}" != "tag', workflow)
         self.assertIn('${tag}" != "v${version}', workflow)
+        self.assertIn('source_commit="$(git rev-parse HEAD)"', workflow)
         self.assertIn(
-            'git merge-base --is-ancestor "${GITHUB_SHA}" origin/main',
+            'git merge-base --is-ancestor "${source_commit}" origin/main',
             workflow,
         )
 


### PR DESCRIPTION
## Summary
- allow a main-branch workflow definition to publish an existing immutable release tag
- check out and validate the requested tag before publishing
- verify ancestry from the actual checked-out source commit
- keep normal tag-push publishing unchanged

## Verification
- [x] focused package and certification contract tests
- [x] dev `ui-tests` run 30292060461
- [x] whitespace checks

## Release recovery
After merge, dispatch `npm-publish.yml` on `main` with `release_ref=v0.5.0`. Do not move or recreate the existing tag.