### PR TITLE
Fix npm publish dependency install

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,8 +39,17 @@ jobs:
           cache: pip
           cache-dependency-path: requirements-dev.txt
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.14.0"
+          cache: npm
+
       - name: Install Python dependencies
         run: python -m pip install -r requirements-dev.txt
+
+      - name: Install npm development dependencies
+        run: npm ci --ignore-scripts
 
       - name: Install Playwright Chromium
         run: python -m playwright install --with-deps chromium
@@ -50,11 +59,6 @@ jobs:
 
       - name: Build catalog
         run: python build.py
-
-      - name: Set up Node for npm
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22.14.0"
 
       - name: Upgrade npm for OIDC trusted publishing
         run: npm install -g npm@11


### PR DESCRIPTION
## Summary

- Install npm development dependencies before publish contract tests
- Reuse the same Node setup for tests and npm publishing

## Verification

- 
added 37 packages, and audited 38 packages in 1s

7 packages are looking for funding
  run `npm fund` for details

3 high severity vulnerabilities

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
- 
- 

No tag, version, or product code changes.