### PR TITLE
Recover v0.7.1 npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       release_ref:
-        description: Existing v* tag to publish while running the workflow definition from the selected branch
+        description: Existing v* tag/version guard to publish while running the workflow definition and package source from the selected branch
         required: false
         type: string
 
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.release_ref || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -91,8 +91,15 @@ jobs:
             echo "Tag ${tag} does not match package version v${version}."
             exit 1
           fi
+          if [ -n "${RELEASE_REF}" ]; then
+            release_commit="$(git rev-list -n 1 "${tag}")"
+            if ! git merge-base --is-ancestor "${release_commit}" origin/main; then
+              echo "Release tag ${tag} does not point to a commit in origin/main history."
+              exit 1
+            fi
+          fi
           if ! git merge-base --is-ancestor "${source_commit}" origin/main; then
-            echo "Tag ${tag} does not point to a commit in origin/main history."
+            echo "Workflow source commit ${source_commit} is not in origin/main history."
             exit 1
           fi
           if npm view "${name}@${version}" version --silent >/dev/null 2>&1; then

--- a/scripts/record-boundary-baseline.py
+++ b/scripts/record-boundary-baseline.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import json
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -54,7 +55,7 @@ def record_boundary_baseline(root: Path = ROOT) -> dict:
     package_dist = root / "dist"
     site_dist = root / "site-dist"
 
-    run([".venv/bin/python", "build.py"], root)
+    run([sys.executable, "build.py"], root)
     pack = json.loads(
         run(["npm", "pack", "--dry-run", "--json"], root).stdout
     )[0]

--- a/tests/test_core_docs_boundary.py
+++ b/tests/test_core_docs_boundary.py
@@ -365,6 +365,14 @@ class CoreDocsBoundaryTests(unittest.TestCase):
             with self.subTest(section=section):
                 self.assertEqual(payload[section], self.fixture[section])
 
+    def test_recorder_uses_the_active_python_interpreter(self) -> None:
+        source = (ROOT / "scripts/record-boundary-baseline.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("sys.executable", source)
+        self.assertNotIn('run([".venv/bin/python", "build.py"]', source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -364,14 +364,25 @@ for (const specifier of [
         )
 
         self.assertIn("release_ref:", workflow)
-        self.assertIn("ref: ${{ inputs.release_ref || github.ref }}", workflow)
+        self.assertIn("tag/version guard", workflow)
+        self.assertIn("ref: ${{ github.ref }}", workflow)
+        self.assertNotIn("ref: ${{ inputs.release_ref || github.ref }}", workflow)
         self.assertIn('tag="${RELEASE_REF:-${GITHUB_REF_NAME}}"', workflow)
         self.assertIn('git show-ref --verify --quiet "refs/tags/${tag}"', workflow)
         self.assertIn('${GITHUB_REF_TYPE}" != "tag', workflow)
         self.assertIn('${tag}" != "v${version}', workflow)
         self.assertIn('source_commit="$(git rev-parse HEAD)"', workflow)
+        self.assertIn('release_commit="$(git rev-list -n 1 "${tag}")"', workflow)
+        self.assertIn(
+            'git merge-base --is-ancestor "${release_commit}" origin/main',
+            workflow,
+        )
         self.assertIn(
             'git merge-base --is-ancestor "${source_commit}" origin/main',
+            workflow,
+        )
+        self.assertIn(
+            'Workflow source commit ${source_commit} is not in origin/main history.',
             workflow,
         )
 


### PR DESCRIPTION
## Summary

- Run boundary baseline recording with the active Python interpreter instead of assuming a local .venv path.
- Keep npm publish workflow checkout on the selected workflow ref so an existing release tag can be published through a fixed main workflow using release_ref.
- Add regression coverage for both recovery contracts.

## Verification

- .venv/bin/python -m unittest tests.test_core_docs_boundary tests.test_package -v
- .venv/bin/python build.py
- env npm_config_cache=/private/tmp/wpmoo-npm-cache .venv/bin/python -m unittest discover -s tests -v (660/660)
- git diff --check
- env npm_config_cache=/private/tmp/wpmoo-npm-cache npm pack --dry-run --json (12 files, @wpmoo/ui@0.7.1)

## Release notes

This does not move or recreate v0.7.1. After merge, run npm-publish.yml from main with release_ref=v0.7.1.