### PR TITLE
Release Moo UI v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,14 @@ recipes, load order, and troubleshooting.
 | `@wpmoo/ui/context-menu.js` | Optional Context Menu ESM lifecycle |
 | `@wpmoo/ui/datatable.js` | Optional DataTable ESM lifecycle |
 | `@wpmoo/ui/sidebar.js` | Optional Sidebar ESM lifecycle |
+| `@wpmoo/ui/scss/facade-settings` | Public Sass variable allow-list (LibSass `@import`) |
 | `@wpmoo/ui/certification.json` | Versioned support/evidence manifest |
 | `@wpmoo/ui/package.json` | Package metadata |
 
 The tarball also contains `README.md`, `LICENSE`, and `ASSET_LICENSE.md`. It
-does not publish catalog templates, preview artwork, catalog JavaScript, SCSS
-source, or a Sass facade. Internal Sass partials and
-Jinja macros are repository build tools, not npm APIs.
+does not publish catalog templates, preview artwork, catalog JavaScript, or
+internal SCSS partials beyond the facade's required settings import. Internal
+Sass partials and Jinja macros are repository build tools, not npm APIs.
 
 ## Why Bootstrap Teams Try It
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ are not part of the npm package.
 
 ## Status And Support
 
-Moo UI is in the `0.x` series. Current package: `@wpmoo/ui@0.8.1`. The
+Moo UI is in the `0.x` series. Current package: `@wpmoo/ui@0.9.0`. The
 package's certification manifest currently has `preview` status; catalog
 availability is WPMoo-maintained preview evidence, not independent or
 accredited certification. Read [Support & Evidence](https://ui.wpmoo.org/support/)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -19,7 +19,11 @@ Moo UI treats the following documented surfaces as public contracts:
   scoped versus unscoped stylesheet behavior;
 - documented exports, options, lifecycle methods, and events of public ESM
   modules;
-- variables explicitly listed by the future public Sass facade;
+- variables explicitly listed by the public Sass facade
+  (`scss/_facade-settings.scss`): `$primary`, `$secondary`, `$success`,
+  `$info`, `$warning`, `$danger`, `$light`, `$dark`, `$body-color`,
+  `$body-bg`, `$border-color`, `$border-radius`, `$border-radius-sm`,
+  `$border-radius-lg`, `$font-size-base`;
 - the certification manifest and support-policy formats once published.
 
 The Jinja macros used to build the catalog are internal build tools and are not

--- a/certification.json
+++ b/certification.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "0.1",
   "status": "preview",
-  "coreVersion": "0.8.1",
+  "coreVersion": "0.9.0",
   "bootstrap": {
     "canonicalVersion": "5.3.3",
     "targetRange": ">=5.3.0 <5.4",

--- a/certification.json
+++ b/certification.json
@@ -26,7 +26,7 @@
       "./context-menu.js",
       "./datatable.js"
     ],
-    "sass": []
+    "sass": ["./scss/facade-settings"]
   },
   "supportPolicy": "https://github.com/wpmoo-org/ui/blob/main/SUPPORT.md"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wpmoo/ui",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wpmoo/ui",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "axe-core": "4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmoo/ui",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Bootstrap markup. shadcn feel. A frontend-framework-free component system for server-rendered apps.",
   "license": "MIT",
   "author": "WPMoo (https://wpmoo.org)",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
     "scss/_facade-settings.scss",
-    "scss/settings/_palette.scss",
+    "scss/settings/_facade_public.scss",
     "certification.json",
     "README.md",
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "./sidebar.js": "./dist/js/sidebar.js",
     "./context-menu.js": "./dist/js/context-menu.js",
     "./datatable.js": "./dist/js/datatable.js",
+    "./scss/facade-settings": "./scss/_facade-settings.scss",
     "./certification.json": "./certification.json",
     "./package.json": "./package.json"
   },
@@ -43,6 +44,8 @@
     "dist/js/sidebar.js",
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
+    "scss/_facade-settings.scss",
+    "scss/settings/_palette.scss",
     "certification.json",
     "README.md",
     "LICENSE",

--- a/scripts/verify_package_contents.py
+++ b/scripts/verify_package_contents.py
@@ -19,6 +19,8 @@ APPROVED_TARBALL_FILES = {
     "dist/js/sidebar.js",
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
+    "scss/_facade-settings.scss",
+    "scss/settings/_palette.scss",
     "package.json",
 }
 

--- a/scripts/verify_package_contents.py
+++ b/scripts/verify_package_contents.py
@@ -20,7 +20,7 @@ APPROVED_TARBALL_FILES = {
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
     "scss/_facade-settings.scss",
-    "scss/settings/_palette.scss",
+    "scss/settings/_facade_public.scss",
     "package.json",
 }
 

--- a/scss/_facade-settings.scss
+++ b/scss/_facade-settings.scss
@@ -48,4 +48,4 @@
 // the public facade. Component-level knobs ($moo-*-dark, $moo-sidebar,
 // etc.) are internal and may change without notice.
 
-@import "settings/palette";
+@import "settings/facade_public";

--- a/scss/_facade-settings.scss
+++ b/scss/_facade-settings.scss
@@ -1,0 +1,51 @@
+// Moo UI — Public Sass Facade: Settings
+//
+// This is the consumer-facing subset of Moo UI's Sass variables.
+// Import this file BEFORE Bootstrap's _variables.scss so your overrides
+// take precedence over Bootstrap's own !default values.
+//
+// Usage (relative-path, Bootstrap Option B pattern):
+//   @import "../node_modules/bootstrap/scss/functions";
+//   @import "../node_modules/@wpmoo/ui/scss/facade-settings";
+//   $primary: #your-brand-color;
+//   @import "../node_modules/bootstrap/scss/variables";
+//   ...
+//
+// Usage (include_paths-based, bundler-configured):
+//   @import "bootstrap/scss/functions";
+//   @import "@wpmoo/ui/scss/facade-settings";
+//   $primary: #your-brand-color;
+//   @import "bootstrap/scss/variables";
+//   ...
+//
+// Public variable allow-list (0.9.0):
+//
+//   Brand colors — any valid Sass color value:
+//     $primary        Default: #171717
+//     $secondary      Default: #f4f4f5
+//     $success        Default: #16803c
+//     $info           Default: #0f6e8c
+//     $warning        Default: #a15c00
+//     $danger         Default: #dc2626
+//     $light          Default: #fafafa
+//     $dark           Default: #18181b
+//
+//   Body — any valid Sass color value:
+//     $body-color     Default: #18181b
+//     $body-bg        Default: #fff
+//
+//   Borders — any valid Sass color (border-color) or CSS <length> (radius):
+//     $border-color   Default: #e4e4e7
+//     $border-radius  Default: 0.5rem
+//     $border-radius-sm  Default: 0.375rem
+//     $border-radius-lg  Default: 0.625rem
+//
+//   Typography — rem/em/unitless ratio (same constraint as Bootstrap's
+//   $font-size-base; see vendor/bootstrap/scss/_variables.scss):
+//     $font-size-base Default: 0.875rem
+//
+// Derived tokens ($moo-*) are computed from the above and are not part of
+// the public facade. Component-level knobs ($moo-*-dark, $moo-sidebar,
+// etc.) are internal and may change without notice.
+
+@import "settings/palette";

--- a/scss/settings/_facade_public.scss
+++ b/scss/settings/_facade_public.scss
@@ -1,0 +1,23 @@
+// Public Sass facade allow-list — the only variables a facade consumer can
+// override. This file is the source of truth for the public Sass surface.
+// _palette.scss imports this first, then declares its own internal additions.
+// Do NOT add variables here without updating the freeze document
+// (src/certification/api-freeze-0.9.0.json) and getting explicit approval.
+
+$primary: #171717 !default;
+$secondary: #f4f4f5 !default;
+$success: #16803c !default;
+$info: #0f6e8c !default;
+$warning: #a15c00 !default;
+$danger: #dc2626 !default;
+$light: #fafafa !default;
+$dark: #18181b !default;
+
+$body-color: #18181b !default;
+$body-bg: #fff !default;
+$font-size-base: 0.875rem !default;
+
+$border-color: #e4e4e7 !default;
+$border-radius: 0.5rem !default;
+$border-radius-sm: 0.375rem !default;
+$border-radius-lg: 0.625rem !default;

--- a/scss/settings/_palette.scss
+++ b/scss/settings/_palette.scss
@@ -1,17 +1,8 @@
+@import "facade_public";
+
 $white: #fff !default;
 $black: #0a0a0a !default;
-$primary: #171717 !default;
-$secondary: #f4f4f5 !default;
-$success: #16803c !default;
-$info: #0f6e8c !default;
-$warning: #a15c00 !default;
-$danger: #dc2626 !default;
-$light: #fafafa !default;
-$dark: #18181b !default;
 
-$body-color: #18181b !default;
-$body-bg: #fff !default;
-$font-size-base: 0.875rem !default;
 $headings-font-weight: 600 !default;
 $lead-font-size: 1.125rem !default;
 $lead-font-weight: 400 !default;
@@ -29,10 +20,6 @@ $display-font-sizes: (
   6: 1.5rem
 ) !default;
 $display-font-weight: $headings-font-weight !default;
-$border-color: #e4e4e7 !default;
-$border-radius: 0.5rem !default;
-$border-radius-sm: 0.375rem !default;
-$border-radius-lg: 0.625rem !default;
 
 // Moo's runtime palette is emitted by both the standalone :root build and the
 // scoped Odoo core build. Keep values centralized here so the two entrypoints

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -35,11 +35,13 @@ not independent or accredited certification.
 - `@wpmoo/ui/context-menu.js`: optional Context Menu ESM lifecycle
 - `@wpmoo/ui/datatable.js`: optional DataTable ESM lifecycle
 - `@wpmoo/ui/sidebar.js`: optional Sidebar ESM lifecycle
+- `@wpmoo/ui/scss/facade-settings`: public Sass variable allow-list (LibSass `@import`)
 - `@wpmoo/ui/certification.json`: versioned support and evidence manifest
 - `@wpmoo/ui/package.json`: package metadata
 
 The npm package does not publish catalog templates, preview artwork, catalog
-JavaScript, SCSS source, or a Sass facade.
+JavaScript, or internal SCSS partials beyond the facade's required settings
+import.
 
 ## Installation Facts
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Bootstrap markup. shadcn feel.
 
-Moo UI 0.8.1 is a Bootstrap 5.3-native component system with a restrained,
+Moo UI 0.9.0 is a Bootstrap 5.3-native component system with a restrained,
 shadcn-inspired visual language for server-rendered and Bootstrap-native apps.
 It is CSS-first, not JavaScript-free: Bootstrap owns native plugin behavior,
 while Moo UI adds optional, explicit ESM only for documented gaps.
@@ -14,7 +14,7 @@ implementation.
 
 ## Version And Support
 
-- npm package: `@wpmoo/ui@0.8.1`
+- npm package: `@wpmoo/ui@0.9.0`
 - Bootstrap peer range: `>=5.3.0 <5.4`
 - Tested Bootstrap versions in the manifest: `5.3.0`, `5.3.3`, `5.3.8`
 - License: MIT for source code
@@ -45,7 +45,7 @@ import.
 
 ## Installation Facts
 
-- CDN full stylesheet: `https://unpkg.com/@wpmoo/ui@0.8.1/dist/assets/css/moo-ui.css`
+- CDN full stylesheet: `https://unpkg.com/@wpmoo/ui@0.9.0/dist/assets/css/moo-ui.css`
 
 Full replacement:
 

--- a/site/src/pages/installation.html.jinja
+++ b/site/src/pages/installation.html.jinja
@@ -112,17 +112,26 @@
       <section class="moo-doc-section" aria-labelledby="optional-esm">
         {{ typography("Optional Moo ESM", variant="section-title", id="optional-esm") }}
         <p>
-          Combobox and Sidebar cover behavior gaps Bootstrap does not provide.
-          Their modules are side-effect-free: importing them does not scan the
-          document. Create instances explicitly and dispose them when your host
-          removes the corresponding UI.
+          Combobox, Context Menu, DataTable, and Sidebar cover behavior gaps
+          Bootstrap does not provide. Their modules are side-effect-free:
+          importing them does not scan the document. Create instances
+          explicitly and dispose them when your host removes the corresponding
+          UI.
         </p>
         {% set esm_example %}
         import Combobox from "@wpmoo/ui/combobox.js";
+        import ContextMenu from "@wpmoo/ui/context-menu.js";
+        import DataTable from "@wpmoo/ui/datatable.js";
         import Sidebar from "@wpmoo/ui/sidebar.js";
 
         const combobox = Combobox.getOrCreateInstance(
           document.querySelector(".combobox")
+        );
+        const contextMenu = ContextMenu.getOrCreateInstance(
+          document.querySelector(".context-menu")
+        );
+        const datatable = DataTable.getOrCreateInstance(
+          document.querySelector(".datatable")
         );
         const sidebar = Sidebar.getOrCreateInstance(
           document.querySelector('[data-slot="sidebar-wrapper"]')
@@ -130,17 +139,31 @@
 
         // Later, when the host removes the UI:
         combobox.dispose();
+        contextMenu.dispose();
+        datatable.dispose();
         sidebar.dispose();
         {% endset %}
         {{ render_code_snippet("installation-esm", esm_example, "js") }}
         {% set esm_cdn_example %}
         <script type="module">
           import Combobox from "https://cdn.jsdelivr.net/npm/@wpmoo/ui@{{ product.version }}/{{ product.exports["./combobox.js"] | replace("./", "") }}";
+          import ContextMenu from "https://cdn.jsdelivr.net/npm/@wpmoo/ui@{{ product.version }}/{{ product.exports["./context-menu.js"] | replace("./", "") }}";
+          import DataTable from "https://cdn.jsdelivr.net/npm/@wpmoo/ui@{{ product.version }}/{{ product.exports["./datatable.js"] | replace("./", "") }}";
           import Sidebar from "https://cdn.jsdelivr.net/npm/@wpmoo/ui@{{ product.version }}/{{ product.exports["./sidebar.js"] | replace("./", "") }}";
 
           const comboboxRoot = document.querySelector(".combobox");
           if (comboboxRoot) {
             Combobox.getOrCreateInstance(comboboxRoot);
+          }
+
+          const contextMenuRoot = document.querySelector(".context-menu");
+          if (contextMenuRoot) {
+            ContextMenu.getOrCreateInstance(contextMenuRoot);
+          }
+
+          const datatableRoot = document.querySelector(".datatable");
+          if (datatableRoot) {
+            DataTable.getOrCreateInstance(datatableRoot);
           }
 
           const sidebarRoot = document.querySelector('[data-slot="sidebar-wrapper"]');
@@ -151,7 +174,9 @@
         {% endset %}
         {{ render_code_snippet("installation-esm-cdn", esm_cdn_example, "html") }}
         <p>
-          Review the <a href="{{ site_href('components/combobox.html', root_path) }}">Combobox</a>
+          Review the <a href="{{ site_href('components/combobox.html', root_path) }}">Combobox</a>,
+          <a href="{{ site_href('components/context-menu.html', root_path) }}">Context Menu</a>,
+          <a href="{{ site_href('components/datatable.html', root_path) }}">Data Table</a>,
           and <a href="{{ site_href('components/sidebar.html', root_path) }}">Sidebar</a>
           pages for their HTML, selectors, lifecycle, and Bootstrap ownership.
         </p>
@@ -166,8 +191,8 @@
           <dd>Confirm <code>moo.css</code> loads after Bootstrap CSS and the migrated markup has a <code>.moo-ui</code> ancestor.</dd>
           <dt>A Bootstrap control does not open</dt>
           <dd>Load Bootstrap's bundle and follow that plugin's documented initialization requirements.</dd>
-          <dt>Combobox or Sidebar does not respond</dt>
-          <dd>Import the matching Moo ESM module and initialize the rendered root explicitly; imports never auto-scan.</dd>
+          <dt>A Moo ESM module does not respond</dt>
+          <dd>Import the matching Moo ESM module (Combobox, Context Menu, DataTable, or Sidebar) and initialize the rendered root explicitly; imports never auto-scan.</dd>
         </dl>
         {{ button("Browse Components", variant="outline", size="sm", element="a", href=site_href("components/index.html", root_path)) }}
       </section>

--- a/site/src/pages/support.html.jinja
+++ b/site/src/pages/support.html.jinja
@@ -192,6 +192,11 @@
           or review complete release notes on
           <a href="https://github.com/wpmoo-org/ui/releases">GitHub Releases</a>.
         </p>
+        <p>
+          SemVer and compatibility policy:
+          <a href="{{ product.support.url }}#versioning-before-10">Versioning Before 1.0</a> ·
+          <a href="{{ product.support.url }}#what-counts-as-breaking">What Counts as Breaking</a>
+        </p>
         <div class="d-flex flex-wrap gap-2">
           {{ button("Report an issue", variant="outline", size="sm", element="a", href="https://github.com/wpmoo-org/ui/issues") }}
           {{ button("Contribute", variant="outline", size="sm", element="a", href=site_href("contributing.html", root_path)) }}

--- a/site/src/pages/support.html.jinja
+++ b/site/src/pages/support.html.jinja
@@ -96,6 +96,44 @@
         </div>
       </section>
 
+      <section class="moo-doc-section" aria-labelledby="bootstrap-compatibility">
+        {{ typography("Bootstrap Compatibility", variant="section-title", id="bootstrap-compatibility") }}
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <tbody>
+              <tr>
+                <th scope="row">Canonical build version</th>
+                <td><code>{{ product.certification.bootstrap.canonicalVersion }}</code></td>
+              </tr>
+              <tr>
+                <th scope="row">Peer dependency range</th>
+                <td><code>{{ product.certification.bootstrap.targetRange }}</code></td>
+              </tr>
+              <tr>
+                <th scope="row">Verified range</th>
+                <td><code>{{ product.certification.bootstrap.verifiedRange }}</code></td>
+              </tr>
+              <tr>
+                <th scope="row">Tested versions</th>
+                <td>
+                  {% for version in product.certification.bootstrap.testedVersions %}
+                    <code>{{ version }}</code>{% if not loop.last %}, {% endif %}
+                  {% endfor %}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-body-secondary">
+          Moo UI is built reproducibly against Bootstrap
+          {{ product.certification.bootstrap.canonicalVersion }}. The
+          production-certification program verifies each release against the
+          minimum, canonical, and latest Bootstrap 5.3.x versions. See
+          <a href="{{ product.support.url }}#bootstrap-compatibility">SUPPORT.md</a>
+          for the full compatibility narrative.
+        </p>
+      </section>
+
       <section class="moo-doc-section" aria-labelledby="maturity">
         {{ typography("Maturity", variant="section-title", id="maturity") }}
         <div class="table-responsive">
@@ -141,7 +179,7 @@
           <li>The certification manifest is currently <code>{{ product.certification.status }}</code>.</li>
           <li>Generic host-conformance evidence remains pending in the source evidence inventory.</li>
           <li>Bootstrap 6 is outside the current compatibility contract.</li>
-          <li>Sass source and a Sass facade are not public package entrypoints yet.</li>
+          <li>Sass source is not a public package entrypoint. Only the documented facade (<code>scss/facade-settings</code>) is published.</li>
         </ul>
       </section>
 
@@ -166,6 +204,7 @@
     {{ render_doc_toc([
       {"id": "current-status", "label": "Current Status"},
       {"id": "public-entrypoints", "label": "Public Entrypoints"},
+      {"id": "bootstrap-compatibility", "label": "Bootstrap Compatibility"},
       {"id": "maturity", "label": "Maturity"},
       {"id": "browser-policy", "label": "Browser Policy"},
       {"id": "limitations", "label": "Limitations"},

--- a/src/certification/api-freeze-0.9.0.json
+++ b/src/certification/api-freeze-0.9.0.json
@@ -27,7 +27,7 @@
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
     "scss/_facade-settings.scss",
-    "scss/settings/_palette.scss",
+    "scss/settings/_facade_public.scss",
     "certification.json",
     "README.md",
     "LICENSE",

--- a/src/certification/api-freeze-0.9.0.json
+++ b/src/certification/api-freeze-0.9.0.json
@@ -1,0 +1,147 @@
+{
+  "freezeVersion": "0.9.0",
+  "frozenAt": "2026-08-05",
+  "description": "API freeze audit for the 0.9.0 public API feature freeze. Every entry is traceable to a specific source file and key. Changes to any enumerated surface require explicit reconciliation with this document.",
+
+  "packageExports": [
+    "./moo-ui.css",
+    "./moo-ui.min.css",
+    "./moo.css",
+    "./moo.min.css",
+    "./combobox.js",
+    "./sidebar.js",
+    "./context-menu.js",
+    "./datatable.js",
+    "./scss/facade-settings",
+    "./certification.json",
+    "./package.json"
+  ],
+
+  "packageFiles": [
+    "dist/assets/css/moo-ui.css",
+    "dist/assets/css/moo-ui.min.css",
+    "dist/assets/css/moo.css",
+    "dist/assets/css/moo.min.css",
+    "dist/js/combobox.js",
+    "dist/js/sidebar.js",
+    "dist/js/context-menu.js",
+    "dist/js/datatable.js",
+    "scss/_facade-settings.scss",
+    "scss/settings/_palette.scss",
+    "certification.json",
+    "README.md",
+    "LICENSE",
+    "ASSET_LICENSE.md"
+  ],
+
+  "sassFacadeAllowList": [
+    "$primary",
+    "$secondary",
+    "$success",
+    "$info",
+    "$warning",
+    "$danger",
+    "$light",
+    "$dark",
+    "$body-color",
+    "$body-bg",
+    "$border-color",
+    "$border-radius",
+    "$border-radius-sm",
+    "$border-radius-lg",
+    "$font-size-base"
+  ],
+
+  "esmModules": [
+    {
+      "module": "combobox.js",
+      "export": "./combobox.js",
+      "lifecycle": ["getOrCreateInstance", "dispose"],
+      "source": "src/js/components/combobox.js"
+    },
+    {
+      "module": "sidebar.js",
+      "export": "./sidebar.js",
+      "lifecycle": ["getOrCreateInstance", "dispose"],
+      "source": "src/js/components/sidebar.js"
+    },
+    {
+      "module": "context-menu.js",
+      "export": "./context-menu.js",
+      "lifecycle": ["getOrCreateInstance", "dispose"],
+      "source": "src/js/components/context-menu.js"
+    },
+    {
+      "module": "datatable.js",
+      "export": "./datatable.js",
+      "lifecycle": ["getOrCreateInstance", "dispose"],
+      "source": "src/js/components/datatable.js"
+    }
+  ],
+
+  "cssEntrypoints": [
+    {
+      "export": "./moo-ui.css",
+      "purpose": "Full expanded Bootstrap-compatible CSS build",
+      "scope": "unscoped"
+    },
+    {
+      "export": "./moo-ui.min.css",
+      "purpose": "Full minified CSS build",
+      "scope": "unscoped"
+    },
+    {
+      "export": "./moo.css",
+      "purpose": "Scoped expanded component layer for .moo-ui",
+      "scope": "scoped"
+    },
+    {
+      "export": "./moo.min.css",
+      "purpose": "Scoped minified component layer",
+      "scope": "scoped"
+    }
+  ],
+
+  "bootstrapSupport": {
+    "canonicalVersion": "5.3.3",
+    "targetRange": ">=5.3.0 <5.4",
+    "testedVersions": ["5.3.0", "5.3.3", "5.3.8"],
+    "source": "certification.json"
+  },
+
+  "browserPolicy": {
+    "policy": "Certification is in progress; see SUPPORT.md for the intended browser policy.",
+    "exactEvidenceInAttestation": false,
+    "source": "certification.json"
+  },
+
+  "certificationManifest": {
+    "schemaVersion": "0.1",
+    "requiredFields": [
+      "schemaVersion",
+      "status",
+      "coreVersion",
+      "bootstrap",
+      "browserPolicy",
+      "certifiedComponents",
+      "publicEntrypoints",
+      "supportPolicy"
+    ],
+    "source": "src/certification/manifest.schema.json"
+  },
+
+  "documentationSurfaces": [
+    {
+      "file": "README.md",
+      "tracks": ["package exports", "runtime ownership", "installation paths"]
+    },
+    {
+      "file": "SUPPORT.md",
+      "tracks": ["SemVer policy", "breaking changes", "Bootstrap compatibility", "browser policy", "maturity definitions"]
+    },
+    {
+      "file": "site/public/llms.txt",
+      "tracks": ["package exports", "installation facts", "runtime ownership"]
+    }
+  ]
+}

--- a/tests/fixtures/boundary-baseline.json
+++ b/tests/fixtures/boundary-baseline.json
@@ -73,7 +73,7 @@
     "sideEffects": [
       "dist/assets/css/*.css"
     ],
-    "version": "0.8.1"
+    "version": "0.9.0"
   },
   "siteDistFiles": [
     "site-dist/apple-touch-icon.png",

--- a/tests/fixtures/boundary-baseline.json
+++ b/tests/fixtures/boundary-baseline.json
@@ -34,7 +34,7 @@
     "dist/js/sidebar.js",
     "package.json",
     "scss/_facade-settings.scss",
-    "scss/settings/_palette.scss"
+    "scss/settings/_facade_public.scss"
   ],
   "package": {
     "exports": {
@@ -64,7 +64,7 @@
       "dist/js/datatable.js",
       "dist/js/sidebar.js",
       "scss/_facade-settings.scss",
-      "scss/settings/_palette.scss"
+      "scss/settings/_facade_public.scss"
     ],
     "name": "@wpmoo/ui",
     "peerDependencies": {
@@ -396,19 +396,19 @@
     "site-dist/icon-192.png": "681080a5b14510b267344f67c6c0384a87480e6e919ad5d4003190d56c10050b",
     "site-dist/icon-512.png": "0f9e72886c967ba2a2e83bc68be51ce14a0967d641ec1f176ff850a1d9b91dec",
     "site-dist/index.html": "6560ee772fd833da7c29fdcf94629ad86dff319887a93ef818bb837e155dbc92",
-    "site-dist/installation/index.html": "e697bfaab552f4565a76eec5f5aa83e2ad212c890c2084847bb90bef07afed22",
+    "site-dist/installation/index.html": "031ea2042eeb47d112dfa41efe58ccb87d10b756fe0720353926e22d62b9a704",
     "site-dist/introduction/index.html": "8b830bcc274fd8b7c3c636aa6aaebb399176f2ad1442cbbe1dee743dd5ae4764",
     "site-dist/js/combobox.js": "3b3ee1c7ec72c21cbfcf4442d084f86504955e3147b7c16f6ebbd74ef4eed98b",
     "site-dist/js/context-menu.js": "831ce547e51c91539f85279c9596528da18403f095f36e4913b2f1526d426076",
     "site-dist/js/datatable.js": "0c4a5db2028845aaec1bc3dc4946b3e3d26b4613e3cb6d7f813fd2e44dfcab93",
     "site-dist/js/sidebar.js": "96dec88d1e265baca1cb72684cacf01ce40dd5fa98ca7c8627f8c002e93d6cf1",
     "site-dist/license/index.html": "df4b491c1875307e63c1bcb63903744e330b1b864fbc9c6de109cd7e871a25e4",
-    "site-dist/llms.txt": "674903a6f8c20586f0cd666d213a502305575d93a176d4bd6cf7e6b115f376d4",
+    "site-dist/llms.txt": "a58dee5095545a40041476b7ce236ec29f8ff7fdd0d12c49417ceb453a8c37c0",
     "site-dist/robots.txt": "bf13521a8ca29a68a5ba125d21c65b84b1679a0aae915a9fd08794d1dc6d9fbf",
     "site-dist/site.webmanifest": "af971266a10396df62c991d9e1f4b86be68d7d2bb248b83386a7ba7f1820fbde",
     "site-dist/sitemap.xml": "a6c08c4c55a6f2a6263c64c88efe91a8af04e61f3eb7cc0abcb90f374a77ef43",
     "site-dist/skills/index.html": "80f122964b38174387e396c009a9a55dcc1d00c4158edcfa39cb78cdfffcc65e",
-    "site-dist/support/index.html": "edea3bb719fa59f8940d1e13773c030eea5ea42823e468fd3680badf67389410",
+    "site-dist/support/index.html": "477d7ab9aa7be841c5909ea5ad273ddddf6d7ec4855f2dada5244850dc6763d4",
     "site-dist/utils/scroll-fade/index.html": "ac587d52c32878fcfec1e1123c0e60b5fcc8a7b9ecd26bfc1ef4a6ba21951541"
   }
 }

--- a/tests/fixtures/boundary-baseline.json
+++ b/tests/fixtures/boundary-baseline.json
@@ -32,7 +32,9 @@
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
     "dist/js/sidebar.js",
-    "package.json"
+    "package.json",
+    "scss/_facade-settings.scss",
+    "scss/settings/_palette.scss"
   ],
   "package": {
     "exports": {
@@ -45,6 +47,7 @@
       "./moo.css": "./dist/assets/css/moo.css",
       "./moo.min.css": "./dist/assets/css/moo.min.css",
       "./package.json": "./package.json",
+      "./scss/facade-settings": "./scss/_facade-settings.scss",
       "./sidebar.js": "./dist/js/sidebar.js"
     },
     "files": [
@@ -59,7 +62,9 @@
       "dist/js/combobox.js",
       "dist/js/context-menu.js",
       "dist/js/datatable.js",
-      "dist/js/sidebar.js"
+      "dist/js/sidebar.js",
+      "scss/_facade-settings.scss",
+      "scss/settings/_palette.scss"
     ],
     "name": "@wpmoo/ui",
     "peerDependencies": {
@@ -341,7 +346,7 @@
     "site-dist/blocks/previews/sidebar-inset/index.html": "a38d4513ea564841dcfb722ab6544707117bf8069decec2d71c230483f9862de",
     "site-dist/blocks/sidebar-floating/index.html": "d997a3a3919904862256bee8a8d50f0242275cbbf660d5bb242a9de2e4deb378",
     "site-dist/blocks/sidebar-inset/index.html": "c224d3a70e7b854c7b72a1c34b173d70a3e7563d77474a02ef00f0c1466194c9",
-    "site-dist/changelog/index.html": "d9d1f63f3419212da8c5db332bb25de7fa719236864d91d6a5f9c9e40824d344",
+    "site-dist/changelog/index.html": "466587c1f4be6a10cc130948d784897e763de66050d430d7599c90d2cb7562b9",
     "site-dist/components/accordion/index.html": "91eb91f0757ddaceca8946362e0f8b2a1f643a2b1d8b6040ead9363b84e07f3e",
     "site-dist/components/alert-dialog/index.html": "f812286b8c8e011611d4e6d36ac97dccb56b45306e0880fff57e5c0db14ea722",
     "site-dist/components/alert/index.html": "addf323c8ab1a29f8bb65e7e45d879aabaa7086992dee013e4043d31b52b813a",
@@ -390,20 +395,20 @@
     "site-dist/favicon.svg": "faf1d513e3c7cdd2c17ee5fc2db6667fb7f99313562c6218cb8e2395aec0dc39",
     "site-dist/icon-192.png": "681080a5b14510b267344f67c6c0384a87480e6e919ad5d4003190d56c10050b",
     "site-dist/icon-512.png": "0f9e72886c967ba2a2e83bc68be51ce14a0967d641ec1f176ff850a1d9b91dec",
-    "site-dist/index.html": "4b356ccc9ba1931396446742e7c4c5ce91508be2dfac82254c6ed946e16c5018",
-    "site-dist/installation/index.html": "ddebf25f8ecbf68eea710b828b019963b533c21f9eebe12510bcfb6b4e03632e",
+    "site-dist/index.html": "6560ee772fd833da7c29fdcf94629ad86dff319887a93ef818bb837e155dbc92",
+    "site-dist/installation/index.html": "e697bfaab552f4565a76eec5f5aa83e2ad212c890c2084847bb90bef07afed22",
     "site-dist/introduction/index.html": "8b830bcc274fd8b7c3c636aa6aaebb399176f2ad1442cbbe1dee743dd5ae4764",
     "site-dist/js/combobox.js": "3b3ee1c7ec72c21cbfcf4442d084f86504955e3147b7c16f6ebbd74ef4eed98b",
     "site-dist/js/context-menu.js": "831ce547e51c91539f85279c9596528da18403f095f36e4913b2f1526d426076",
     "site-dist/js/datatable.js": "0c4a5db2028845aaec1bc3dc4946b3e3d26b4613e3cb6d7f813fd2e44dfcab93",
     "site-dist/js/sidebar.js": "96dec88d1e265baca1cb72684cacf01ce40dd5fa98ca7c8627f8c002e93d6cf1",
     "site-dist/license/index.html": "df4b491c1875307e63c1bcb63903744e330b1b864fbc9c6de109cd7e871a25e4",
-    "site-dist/llms.txt": "d64ce73a397a6f9584197d0885c83b34b3721e304243baf64afe464a389ad87b",
+    "site-dist/llms.txt": "674903a6f8c20586f0cd666d213a502305575d93a176d4bd6cf7e6b115f376d4",
     "site-dist/robots.txt": "bf13521a8ca29a68a5ba125d21c65b84b1679a0aae915a9fd08794d1dc6d9fbf",
     "site-dist/site.webmanifest": "af971266a10396df62c991d9e1f4b86be68d7d2bb248b83386a7ba7f1820fbde",
     "site-dist/sitemap.xml": "a6c08c4c55a6f2a6263c64c88efe91a8af04e61f3eb7cc0abcb90f374a77ef43",
-    "site-dist/skills/index.html": "67393c5a39a6ed09868c1a8f698de8279cc0f1a45e54c510c4b60261c145d733",
-    "site-dist/support/index.html": "f5f2a8c3da302e0f90534b33c688868a7e25c205bdf27b8325324785477ab4e5",
+    "site-dist/skills/index.html": "80f122964b38174387e396c009a9a55dcc1d00c4158edcfa39cb78cdfffcc65e",
+    "site-dist/support/index.html": "edea3bb719fa59f8940d1e13773c030eea5ea42823e468fd3680badf67389410",
     "site-dist/utils/scroll-fade/index.html": "ac587d52c32878fcfec1e1123c0e60b5fcc8a7b9ecd26bfc1ef4a6ba21951541"
   }
 }

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -42,6 +42,7 @@ def read_scss_aggregate(
     if source_root is None:
         source_root = ROOT / "scss"
     paths = [entrypoint]
+    queue: list[Path] = []
     for target in active_scss_imports(source):
         if not target.startswith(f"{prefix}/"):
             continue
@@ -50,6 +51,23 @@ def read_scss_aggregate(
         if not partial.is_file():
             raise FileNotFoundError(f"Missing imported Sass partial: {partial}")
         paths.append(partial)
+        queue.append(partial)
+    seen = set(paths)
+    # Follow imports nested inside the included partials (e.g.
+    # settings/_palette.scss importing facade_public) so their
+    # declarations still contribute to the aggregate.
+    while queue:
+        current = queue.pop(0)
+        for target in active_scss_imports(current.read_text(encoding="utf-8")):
+            relative = Path(target)
+            partial = current.parent / f"_{relative.name}.scss"
+            if not partial.is_file():
+                raise FileNotFoundError(f"Missing imported Sass partial: {partial}")
+            if partial in seen:
+                continue
+            seen.add(partial)
+            paths.append(partial)
+            queue.append(partial)
     return "\n".join(path.read_text(encoding="utf-8") for path in paths)
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -948,9 +948,13 @@ class CatalogContractTests(CatalogTestCase):
         version = package["version"]
         bootstrap_version = certification["bootstrap"]["canonicalVersion"]
         combobox_export = package["exports"]["./combobox.js"].removeprefix("./")
+        context_menu_export = package["exports"]["./context-menu.js"].removeprefix("./")
+        datatable_export = package["exports"]["./datatable.js"].removeprefix("./")
         sidebar_export = package["exports"]["./sidebar.js"].removeprefix("./")
 
         self.assertIn(combobox_export, package["files"])
+        self.assertIn(context_menu_export, package["files"])
+        self.assertIn(datatable_export, package["files"])
         self.assertIn(sidebar_export, package["files"])
 
         self.assertIn(
@@ -973,9 +977,19 @@ class CatalogContractTests(CatalogTestCase):
         self.assertIn("Bootstrap JavaScript", installation)
         self.assertIn("Optional Moo ESM", installation)
         self.assertIn('href="../components/combobox/">Combobox</a>', installation)
+        self.assertIn('href="../components/context-menu/">Context Menu</a>', installation)
+        self.assertIn('href="../components/datatable/">Data Table</a>', installation)
         self.assertIn('href="../components/sidebar/">Sidebar</a>', installation)
         self.assertIn(
             'import Combobox from &quot;@wpmoo/ui/combobox.js&quot;',
+            installation,
+        )
+        self.assertIn(
+            'import ContextMenu from &quot;@wpmoo/ui/context-menu.js&quot;',
+            installation,
+        )
+        self.assertIn(
+            'import DataTable from &quot;@wpmoo/ui/datatable.js&quot;',
             installation,
         )
         self.assertIn(
@@ -987,10 +1001,20 @@ class CatalogContractTests(CatalogTestCase):
             installation,
         )
         self.assertIn(
+            f"https://cdn.jsdelivr.net/npm/@wpmoo/ui@{version}/{context_menu_export}",
+            installation,
+        )
+        self.assertIn(
+            f"https://cdn.jsdelivr.net/npm/@wpmoo/ui@{version}/{datatable_export}",
+            installation,
+        )
+        self.assertIn(
             f"https://cdn.jsdelivr.net/npm/@wpmoo/ui@{version}/{sidebar_export}",
             installation,
         )
         self.assertIn("Combobox.getOrCreateInstance", installation)
+        self.assertIn("ContextMenu.getOrCreateInstance", installation)
+        self.assertIn("DataTable.getOrCreateInstance", installation)
         self.assertIn("Sidebar.getOrCreateInstance", installation)
         self.assertIn("Scoped Gradual Adoption", installation)
         self.assertIn("moo-ui", installation)

--- a/tests/test_certification_contract.py
+++ b/tests/test_certification_contract.py
@@ -402,6 +402,58 @@ class CertificationContractTests(unittest.TestCase):
                 for term in forbidden_terms:
                     self.assertNotIn(term, content)
 
+    def test_api_freeze_document_matches_live_package_state(self) -> None:
+        """Lock the 0.9.0 API freeze: any undocumented addition or removal
+        to the public surfaces must fail CI until the freeze document and
+        the change are reconciled on purpose."""
+        freeze = self._read_json("src/certification/api-freeze-0.9.0.json")
+        package = self._read_json("package.json")
+        certification = self._read_json("certification.json")
+        schema = self._read_json("src/certification/manifest.schema.json")
+
+        # Package exports must match exactly
+        live_exports = set(package["exports"].keys())
+        frozen_exports = set(freeze["packageExports"])
+        self.assertEqual(live_exports, frozen_exports,
+            "package.json exports diverged from the 0.9.0 freeze document")
+
+        # Package files must match exactly
+        live_files = set(package["files"])
+        frozen_files = set(freeze["packageFiles"])
+        self.assertEqual(live_files, frozen_files,
+            "package.json files diverged from the 0.9.0 freeze document")
+
+        # Sass facade allow-list must match the facade source
+        facade_source = (ROOT / "scss/_facade-settings.scss").read_text(encoding="utf-8")
+        frozen_sass_vars = set(freeze["sassFacadeAllowList"])
+        # Extract variable names documented in the facade header
+        import re
+        documented_vars = set(re.findall(r'\$[\w-]+(?=\s)', facade_source))
+        # Filter to only the allow-listed ones (exclude $moo-* derived tokens)
+        public_vars = {v for v in documented_vars if not v.startswith("$moo-")}
+        self.assertEqual(frozen_sass_vars, public_vars,
+            "Sass facade allow-list diverged from the freeze document")
+
+        # Certification manifest schema required fields must match
+        live_required = set(schema["required"])
+        frozen_required = set(freeze["certificationManifest"]["requiredFields"])
+        self.assertEqual(live_required, frozen_required,
+            "manifest.schema.json required fields diverged from the freeze document")
+
+        # Bootstrap support must match certification.json
+        self.assertEqual(
+            freeze["bootstrapSupport"]["canonicalVersion"],
+            certification["bootstrap"]["canonicalVersion"],
+        )
+        self.assertEqual(
+            freeze["bootstrapSupport"]["targetRange"],
+            certification["bootstrap"]["targetRange"],
+        )
+        self.assertEqual(
+            freeze["bootstrapSupport"]["testedVersions"],
+            certification["bootstrap"]["testedVersions"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_certification_contract.py
+++ b/tests/test_certification_contract.py
@@ -423,16 +423,31 @@ class CertificationContractTests(unittest.TestCase):
         self.assertEqual(live_files, frozen_files,
             "package.json files diverged from the 0.9.0 freeze document")
 
-        # Sass facade allow-list must match the facade source
-        facade_source = (ROOT / "scss/_facade-settings.scss").read_text(encoding="utf-8")
-        frozen_sass_vars = set(freeze["sassFacadeAllowList"])
-        # Extract variable names documented in the facade header
+        # Sass facade allow-list must match the real public declarations.
+        # Extract variable names from the actual !default declarations in
+        # the narrow public partial -- not from facade comments -- so any
+        # widening of the public surface (e.g. re-importing the full
+        # internal palette into _facade_public.scss) grows the extracted
+        # set past the freeze document and fails for real.
         import re
-        documented_vars = set(re.findall(r'\$[\w-]+(?=\s)', facade_source))
-        # Filter to only the allow-listed ones (exclude $moo-* derived tokens)
-        public_vars = {v for v in documented_vars if not v.startswith("$moo-")}
-        self.assertEqual(frozen_sass_vars, public_vars,
+        facade_public_source = (ROOT / "scss/settings/_facade_public.scss").read_text(encoding="utf-8")
+        frozen_sass_vars = set(freeze["sassFacadeAllowList"])
+        declared_vars = set(re.findall(r'^(\$[\w-]+)\s*:\s*[^;]*!default\s*;', facade_public_source, re.MULTILINE))
+        self.assertEqual(frozen_sass_vars, declared_vars,
             "Sass facade allow-list diverged from the freeze document")
+
+        # The facade itself may only import the narrow public partial;
+        # importing the full internal palette would re-leak ~35 variables.
+        facade_source = (ROOT / "scss/_facade-settings.scss").read_text(encoding="utf-8")
+        # Strip comments first so the documented usage recipes in the
+        # header are not mistaken for real imports.
+        stripped_facade = re.sub(r"/\*.*?\*/", "", facade_source, flags=re.DOTALL)
+        stripped_facade = "\n".join(
+            line.split("//", 1)[0] for line in stripped_facade.splitlines()
+        )
+        facade_imports = set(re.findall(r'@import\s+"([^"]+)"\s*;', stripped_facade))
+        self.assertEqual(facade_imports, {"settings/facade_public"},
+            "facade-settings must import only the narrow public partial")
 
         # Certification manifest schema required fields must match
         live_required = set(schema["required"])

--- a/tests/test_design_gates.py
+++ b/tests/test_design_gates.py
@@ -334,6 +334,7 @@ class DesignGateTests(CatalogTestCase):
             {
                 "_bootstrap_component_layer.scss",
                 "_component_layer.scss",
+                "_facade-settings.scss",
                 "_primary_variables.scss",
                 "moo-core.scss",
                 "moo-ui.scss",

--- a/tests/test_design_gates.py
+++ b/tests/test_design_gates.py
@@ -383,7 +383,17 @@ class DesignGateTests(CatalogTestCase):
         ]
 
         self.assertEqual(imports, expected)
-        self.assertEqual(owned_partial_targets(SCSS / "settings"), set(expected))
+        # _facade_public.scss is the narrow public allow-list: it is owned
+        # by _palette.scss's leading import (and by the public facade), not
+        # a direct _primary_variables.scss import.
+        self.assertEqual(
+            owned_partial_targets(SCSS / "settings"),
+            set(expected) | {"settings/facade_public"},
+        )
+        palette_imports = active_scss_import_list(
+            (SCSS / "settings/_palette.scss").read_text(encoding="utf-8")
+        )
+        self.assertEqual(palette_imports[:1], ["facade_public"])
 
     def test_entrypoints_import_theme_and_foundation_layers_in_order(self) -> None:
         entrypoint_imports = {

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -19,6 +19,8 @@ EXPECTED_PACKAGE_FILES = {
     "dist/js/sidebar.js",
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
+    "scss/_facade-settings.scss",
+    "scss/settings/_palette.scss",
     "certification.json",
     "README.md",
     "LICENSE",
@@ -33,6 +35,7 @@ EXPECTED_PACKAGE_EXPORTS = {
     "./sidebar.js": "./dist/js/sidebar.js",
     "./context-menu.js": "./dist/js/context-menu.js",
     "./datatable.js": "./dist/js/datatable.js",
+    "./scss/facade-settings": "./scss/_facade-settings.scss",
     "./certification.json": "./certification.json",
     "./package.json": "./package.json",
 }

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -360,6 +360,92 @@ for (const specifier of [
             )
             self.assertEqual(consumer_result.returncode, 0, consumer_result.stderr)
 
+    def test_sass_facade_compiles_from_a_clean_consumer(self) -> None:
+        """Phase 0C discipline: test the facade from a clean consumer
+        fixture without source-tree shortcuts. Mirrors the tarball-install
+        pattern from test_real_tarball_resolves_from_a_clean_consumer."""
+        import sass
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            pack_result = subprocess.run(
+                ["npm", "pack", "--json", "--pack-destination", str(temporary_root)],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(pack_result.returncode, 0, pack_result.stderr)
+            pack_payload = json.loads(pack_result.stdout)
+            tarball = temporary_root / pack_payload[0]["filename"]
+            self.assertTrue(tarball.is_file())
+
+            # Unpack into a consumer node_modules layout
+            unpack_root = temporary_root / "unpacked"
+            with tarfile.open(tarball, mode="r:gz") as archive:
+                archive.extractall(unpack_root)
+            consumer_root = temporary_root / "consumer"
+            installed_package = consumer_root / "node_modules/@wpmoo/ui"
+            installed_package.parent.mkdir(parents=True)
+            shutil.move(unpack_root / "package", installed_package)
+
+            # Install bootstrap@5.3.3 alongside
+            bootstrap_pkg = consumer_root / "node_modules/bootstrap/scss"
+            bootstrap_pkg.mkdir(parents=True)
+            vendor_bootstrap_scss = ROOT / "vendor/bootstrap/scss"
+            for item in vendor_bootstrap_scss.iterdir():
+                dest = bootstrap_pkg / item.name
+                if item.is_file():
+                    shutil.copy2(item, dest)
+                elif item.is_dir():
+                    shutil.copytree(item, dest)
+
+            # --- Assertion 1: zero overrides compiles ---
+            scss_dir = consumer_root / "scss"
+            scss_dir.mkdir(exist_ok=True)
+            (scss_dir / "defaults.scss").write_text(
+                '@import "@wpmoo/ui/scss/facade-settings";\n'
+                "@import \"bootstrap/scss/functions\";\n"
+                "@import \"bootstrap/scss/variables\";\n"
+                "@import \"bootstrap/scss/variables-dark\";\n"
+                "@import \"bootstrap/scss/maps\";\n"
+                "@import \"bootstrap/scss/mixins\";\n"
+                "@import \"bootstrap/scss/root\";\n",
+                encoding="utf-8",
+            )
+            css_defaults = sass.compile(
+                filename=str(scss_dir / "defaults.scss"),
+                include_paths=[str(consumer_root / "node_modules")],
+                output_style="expanded",
+            )
+            self.assertIn("--bs-body-color:", css_defaults)
+
+            # --- Assertion 2: overriding $primary changes the output ---
+            (scss_dir / "override.scss").write_text(
+                '@import "@wpmoo/ui/scss/facade-settings";\n'
+                "$primary: #3b82f6;\n"
+                '@import "bootstrap/scss/functions";\n'
+                '@import "bootstrap/scss/variables";\n'
+                '@import "bootstrap/scss/maps";\n'
+                '@import "bootstrap/scss/mixins";\n'
+                '@import "bootstrap/scss/root";\n',
+                encoding="utf-8",
+            )
+            css_override = sass.compile(
+                filename=str(scss_dir / "override.scss"),
+                include_paths=[str(consumer_root / "node_modules")],
+                output_style="expanded",
+            )
+            self.assertIn("#3b82f6", css_override)
+            self.assertNotIn(css_defaults, css_override)
+
+            # --- Assertion 3: no internal partial paths leaked ---
+            for output in (css_defaults, css_override):
+                self.assertNotIn("settings/", output)
+                self.assertNotIn("_palette", output)
+                self.assertNotIn("_components", output)
+                self.assertNotIn("_forms", output)
+
     def test_component_module_imports_have_no_document_side_effect(self) -> None:
         for module_name in (
             "combobox.js",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -20,7 +20,7 @@ EXPECTED_PACKAGE_FILES = {
     "dist/js/context-menu.js",
     "dist/js/datatable.js",
     "scss/_facade-settings.scss",
-    "scss/settings/_palette.scss",
+    "scss/settings/_facade_public.scss",
     "certification.json",
     "README.md",
     "LICENSE",
@@ -445,6 +445,30 @@ for (const specifier of [
                 self.assertNotIn("_palette", output)
                 self.assertNotIn("_components", output)
                 self.assertNotIn("_forms", output)
+
+            # --- Assertion 4: non-allow-listed variables must not leak ---
+            # The facade may only expose the frozen 15-variable allow-list.
+            # Referencing an internal declaration ($white from the palette,
+            # $moo-destructive derived token) after the facade import must
+            # fail with Sass's own undefined-variable error. If the facade
+            # ever re-imports the full internal settings partial, these
+            # compilations succeed and this assertion fails for real.
+            for leaked_variable in ("$white", "$moo-destructive"):
+                with self.subTest(leaked_variable=leaked_variable):
+                    (scss_dir / "leak.scss").write_text(
+                        '@import "@wpmoo/ui/scss/facade-settings";\n'
+                        f".leak-test {{ color: {leaked_variable}; }}\n",
+                        encoding="utf-8",
+                    )
+                    with self.assertRaises(sass.CompileError) as leak_context:
+                        sass.compile(
+                            filename=str(scss_dir / "leak.scss"),
+                            include_paths=[str(consumer_root / "node_modules")],
+                            output_style="expanded",
+                        )
+                    self.assertIn(
+                        "Undefined variable", str(leak_context.exception)
+                    )
 
     def test_component_module_imports_have_no_document_side_effect(self) -> None:
         for module_name in (


### PR DESCRIPTION
Release automation for v0.9.0: version bump only. Carries Phase 4 work already on dev — public Sass facade with the frozen 15-variable allow-list (including the facade-leak split fix), adoption docs, and the API freeze audit with its CI lock.