### PR TITLE
CI: bump GitHub Actions to Node 24-native majors

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,20 +27,20 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.5"
           cache: pip
           cache-dependency-path: requirements-dev.txt
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.14.0"
           cache: npm

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ui-ci.yml
+++ b/.github/workflows/ui-ci.yml
@@ -25,17 +25,17 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11.5"
           cache: pip
           cache-dependency-path: requirements-dev.txt
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm


### PR DESCRIPTION
Bumps checkout@v4, setup-node@v4, setup-python@v5 to v7 across ui-ci.yml, npm-publish.yml, and release-tag.yml to clear the Node.js 20 deprecation annotation before GitHub removes Node 20 from runners on 2026-09-16. Version pins only; no with: inputs, triggers, or job structure changed. Breaking-change review recorded in the commit message.