### PR TITLE
Phase 5 Tasks 8-9: hash-locked conformance kit artifact + SUPPORT.md docs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -128,3 +128,16 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Attach conformance kit artifact
+        if: startsWith(steps.package.outputs.tag, 'v')
+        run: |
+          tag="${{ steps.package.outputs.tag }}"
+          kit_version="$(python -c "import json; print(json.load(open('conformance/contract/conformance-contract.json'))['schemaVersion'])")"
+          python scripts/package-conformance-kit.py --version "${kit_version}"
+          gh release upload "${tag}" \
+            "dist/conformance-kit/moo-ui-conformance-kit-${kit_version}.tar.gz" \
+            "dist/conformance-kit/moo-ui-conformance-kit-${kit_version}.tar.gz.sha256" \
+            --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -133,6 +133,11 @@ jobs:
         if: startsWith(steps.package.outputs.tag, 'v')
         run: |
           tag="${{ steps.package.outputs.tag }}"
+          # Build the kit from the tagged commit, not the workflow ref:
+          # with inputs.release_ref the checkout may be a later commit
+          # carrying the same package version, and the release asset
+          # must match the commit the release tag points to.
+          git checkout --detach "${tag}"
           kit_version="$(python -c "import json; print(json.load(open('conformance/contract/conformance-contract.json'))['schemaVersion'])")"
           python scripts/package-conformance-kit.py --version "${kit_version}"
           gh release upload "${tag}" \

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -158,10 +158,32 @@ the package version they apply to.
 
 ## Generic Host Conformance
 
-Moo UI will publish a host-neutral conformance contract and fixture bundle as a
-language-neutral, hash-locked GitHub Release artifact. It will test concerns
-such as CSS resets, asset order, scoping, direction, themes, focus, overlays,
-plugin lifecycle, Content Security Policy, and console health.
+Moo UI publishes the Generic Host Conformance Kit: a host-neutral contract,
+a bundle of canonical fixture pages, a reference runner, and an example host
+shell. It is distributed as a deterministic, hash-locked GitHub Release
+artifact (`moo-ui-conformance-kit-<version>.tar.gz` plus a `.sha256`
+sidecar) attached to Moo UI releases; the first published archive ships
+with the next release. The contract checks concerns such as CSS resets,
+asset order, scoping, direction, themes, focus, overlays, plugin lifecycle,
+Content Security Policy, and console health.
+
+A host runs the kit in three steps: extract the archive, serve the fixture
+pages from the environment under test (any static file server works; the
+kit ships an example host shell at `conformance/host-shell/serve.py`), and
+point the reference runner (`conformance/runner/run.py`) at the served
+fixtures. The runner drives the fixtures in a browser and writes a JSON
+report conforming to the kit's report schema
+(`conformance/contract/report.schema.json`); exit code 0 records a
+conformance pass for that host. The runner needs Python 3 and Playwright
+only; no Moo UI build tooling is involved.
+
+The archive is reproducible byte-for-byte from the repository source at any
+time. The current kit carries contract version 1.0, and its archive hashes
+to SHA-256
+`f29b3e7e22273671facb4391a1da005362ea6fb9a05ccf5bdf6c827a48416c3c`.
+Published artifacts are listed on the GitHub Releases page:
+
+https://github.com/wpmoo-org/ui/releases
 
 Passing the generic contract does not automatically grant an “official
 integration” designation. Platform-specific implementation, support, and

--- a/scripts/package-conformance-kit.py
+++ b/scripts/package-conformance-kit.py
@@ -39,6 +39,8 @@ def validate_version(version: str) -> str:
 
     The version is embedded in member names and the output filename, so
     separators or traversal components would be a path-injection vector.
+    This also covers absolute versions, which ``out_dir / archive_name``
+    would otherwise resolve outside the output directory.
     """
     if not version:
         raise ValueError("version must not be empty")
@@ -88,7 +90,7 @@ def build_archive(version: str) -> bytes:
     return gz_buffer.getvalue()
 
 
-def main(argv: list = None) -> int:
+def main(argv: list | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Deterministic packaging of the conformance kit."
     )

--- a/scripts/package-conformance-kit.py
+++ b/scripts/package-conformance-kit.py
@@ -34,6 +34,19 @@ FIXED_MTIME = 0
 FIXED_MODE = 0o644
 
 
+def validate_version(version: str) -> str:
+    """Reject versions that could escape the archive prefix or out-dir.
+
+    The version is embedded in member names and the output filename, so
+    separators or traversal components would be a path-injection vector.
+    """
+    if not version:
+        raise ValueError("version must not be empty")
+    if "/" in version or "\\" in version or ".." in version:
+        raise ValueError(f"version must not contain path separators: {version!r}")
+    return version
+
+
 def kit_files() -> list:
     files = []
     for dir_name in INCLUDED_DIRS:
@@ -52,6 +65,7 @@ def kit_files() -> list:
 
 
 def build_archive(version: str) -> bytes:
+    version = validate_version(version)
     prefix = f"moo-ui-conformance-kit-{version}"
     tar_buffer = io.BytesIO()
     with tarfile.open(fileobj=tar_buffer, mode="w") as tar:

--- a/scripts/package-conformance-kit.py
+++ b/scripts/package-conformance-kit.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Package the Generic Host Conformance Kit as a deterministic archive.
+
+Produces a byte-identical ``.tar.gz`` (and a ``.sha256`` sidecar) for the
+same repository content, regardless of when or where it is built: file
+order is sorted, mtimes/owners/modes are fixed, and gzip embeds no name
+or timestamp.  The archive carries the distributable kit only — contract,
+fixtures, runner, and example host shell — laid out under a versioned
+prefix that preserves the repository-relative ``conformance/`` paths, so
+an extracted copy is directly runnable (``conformance/host-shell/serve.py``
+plus ``conformance/runner/run.py``).  Evidence snapshots under
+``conformance/reports/`` are repository evidence, not kit content, and
+are excluded.
+
+Usage:
+    python scripts/package-conformance-kit.py [--version 1.0] [--out-dir dist/conformance-kit]
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KIT_DIR = ROOT / "conformance"
+INCLUDED_DIRS = ("contract", "fixtures", "runner", "host-shell")
+EXCLUDED_PARTS = {"__pycache__", ".DS_Store"}
+FIXED_MTIME = 0
+FIXED_MODE = 0o644
+
+
+def kit_files() -> list:
+    files = []
+    for dir_name in INCLUDED_DIRS:
+        base = KIT_DIR / dir_name
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in EXCLUDED_PARTS for part in path.relative_to(ROOT).parts):
+                continue
+            files.append(path)
+    return sorted(files, key=lambda p: p.relative_to(KIT_DIR).as_posix())
+
+
+def build_archive(version: str) -> bytes:
+    prefix = f"moo-ui-conformance-kit-{version}"
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+        for path in kit_files():
+            data = path.read_bytes()
+            info = tarfile.TarInfo(
+                name=f"{prefix}/conformance/{path.relative_to(KIT_DIR).as_posix()}"
+            )
+            info.size = len(data)
+            info.mtime = FIXED_MTIME
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            info.mode = FIXED_MODE
+            tar.addfile(info, io.BytesIO(data))
+    gz_buffer = io.BytesIO()
+    with gzip.GzipFile(filename="", mode="wb", fileobj=gz_buffer, mtime=0) as gz:
+        gz.write(tar_buffer.getvalue())
+    return gz_buffer.getvalue()
+
+
+def main(argv: list = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Deterministic packaging of the conformance kit."
+    )
+    parser.add_argument("--version", default="1.0")
+    parser.add_argument(
+        "--out-dir",
+        default=str(ROOT / "dist" / "conformance-kit"),
+    )
+    args = parser.parse_args(argv)
+
+    archive = build_archive(args.version)
+    digest = hashlib.sha256(archive).hexdigest()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = f"moo-ui-conformance-kit-{args.version}.tar.gz"
+    archive_path = out_dir / archive_name
+    archive_path.write_bytes(archive)
+    (out_dir / f"{archive_name}.sha256").write_text(
+        f"{digest}  {archive_name}\n", encoding="utf-8"
+    )
+    print(f"{digest}  {archive_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package-conformance-kit.py
+++ b/scripts/package-conformance-kit.py
@@ -10,7 +10,8 @@ prefix that preserves the repository-relative ``conformance/`` paths, so
 an extracted copy is directly runnable (``conformance/host-shell/serve.py``
 plus ``conformance/runner/run.py``).  Evidence snapshots under
 ``conformance/reports/`` are repository evidence, not kit content, and
-are excluded.
+are excluded.  Symbolic links are rejected so the archive can never
+carry content from outside the repository.
 
 Usage:
     python scripts/package-conformance-kit.py [--version 1.0] [--out-dir dist/conformance-kit]
@@ -38,6 +39,10 @@ def kit_files() -> list:
     for dir_name in INCLUDED_DIRS:
         base = KIT_DIR / dir_name
         for path in base.rglob("*"):
+            if path.is_symlink():
+                raise ValueError(
+                    f"conformance kit must not contain symlinks: {path}"
+                )
             if not path.is_file():
                 continue
             if any(part in EXCLUDED_PARTS for part in path.relative_to(ROOT).parts):

--- a/tests/helpers/host_process.py
+++ b/tests/helpers/host_process.py
@@ -1,0 +1,69 @@
+"""Shared helpers for spawning the example host shell under test.
+
+Both ``test_host_shell`` and ``test_conformance_kit_packaging`` need an
+interpreter outside the repository ``.venv`` and a bounded read of the
+host shell's listening-URL banner; keeping them here avoids one test
+module importing another (which would couple unittest discovery order
+and run the other module's import-time work).
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import shutil
+import subprocess
+import threading
+
+from tests.helpers import ROOT
+
+BANNER_TIMEOUT_SECONDS = 30
+
+
+def non_venv_interpreter() -> str:
+    """Return an interpreter outside the repository .venv, if one exists."""
+    venv_dir = os.path.realpath(str(ROOT / ".venv"))
+    for candidate in ("/usr/bin/python3", shutil.which("python3")):
+        if not candidate:
+            continue
+        resolved = os.path.realpath(candidate)
+        if not os.path.isfile(resolved):
+            continue
+        if resolved.startswith(venv_dir + os.sep):
+            continue
+        return resolved
+    return ""
+
+
+def read_banner_line(server: subprocess.Popen) -> str:
+    """Read the host shell's listening-URL line with a bounded wait.
+
+    ``readline`` alone blocks until the job timeout if the host hangs
+    before printing its URL, and a readiness poll can fire on a partial
+    line.  A daemon thread performs the blocking read and hands the
+    result through a queue, so the wait stays bounded either way; an
+    empty line means the host exited before printing anything and is
+    reported as a failure, not a silent success.
+    """
+    result = queue.Queue()
+
+    def reader() -> None:
+        try:
+            result.put(server.stdout.readline())
+        except Exception as error:
+            result.put(error)
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    try:
+        value = result.get(timeout=BANNER_TIMEOUT_SECONDS)
+    except queue.Empty:
+        raise AssertionError(
+            "host shell did not print its listening URL within "
+            f"{BANNER_TIMEOUT_SECONDS}s"
+        ) from None
+    if isinstance(value, BaseException):
+        raise value
+    if not value:
+        raise AssertionError("host shell exited before printing its URL")
+    return value

--- a/tests/test_conformance_kit_packaging.py
+++ b/tests/test_conformance_kit_packaging.py
@@ -4,7 +4,8 @@ Task 8 acceptance: two independent packaging runs produce byte-identical
 archives and identical hashes.  These tests lock that in CI, verify the
 archive carries exactly the distributable kit (no evidence snapshots, no
 test-only files), and prove an extracted artifact is self-sufficient:
-its own host shell serves it and the reference runner passes against it.
+its own host shell serves it and its own reference runner passes
+against it.
 """
 
 from __future__ import annotations
@@ -22,11 +23,11 @@ import unittest
 from pathlib import Path
 
 from tests.helpers import ROOT
-from tests.test_host_shell import non_venv_interpreter
+from tests.test_host_shell import non_venv_interpreter, read_banner_line
 
 SCRIPT = ROOT / "scripts" / "package-conformance-kit.py"
-RUNNER = ROOT / "conformance" / "runner" / "run.py"
 RUN_TIMEOUT_SECONDS = 240
+PACKAGING_TIMEOUT_SECONDS = 120
 VERSION = "1.0"
 PREFIX = f"moo-ui-conformance-kit-{VERSION}"
 
@@ -46,14 +47,48 @@ class PackagingTests(unittest.TestCase):
         cls.packaging = load_packaging()
         cls.archive = cls.packaging.build_archive(VERSION)
 
-    def test_two_builds_are_byte_identical(self) -> None:
-        first = self.packaging.build_archive(VERSION)
-        second = self.packaging.build_archive(VERSION)
-        self.assertEqual(first, second)
-        self.assertEqual(
-            hashlib.sha256(first).hexdigest(),
-            hashlib.sha256(second).hexdigest(),
-        )
+    def test_two_cli_runs_are_byte_identical(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            out_dirs = []
+            for name in ("first", "second"):
+                out_dir = Path(scratch) / name
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(SCRIPT),
+                        "--version",
+                        VERSION,
+                        "--out-dir",
+                        str(out_dir),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=PACKAGING_TIMEOUT_SECONDS,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                out_dirs.append(out_dir)
+
+            archive_name = f"moo-ui-conformance-kit-{VERSION}.tar.gz"
+            first = (out_dirs[0] / archive_name).read_bytes()
+            second = (out_dirs[1] / archive_name).read_bytes()
+            self.assertEqual(first, second)
+            first_sidecar = (out_dirs[0] / f"{archive_name}.sha256").read_text(
+                encoding="utf-8"
+            )
+            second_sidecar = (out_dirs[1] / f"{archive_name}.sha256").read_text(
+                encoding="utf-8"
+            )
+            self.assertEqual(first_sidecar, second_sidecar)
+            digest = hashlib.sha256(first).hexdigest()
+            self.assertEqual(first_sidecar, f"{digest}  {archive_name}\n")
+
+    def test_symlinked_kit_content_is_rejected(self) -> None:
+        probe = self.packaging.KIT_DIR / "fixtures" / "_symlink_probe.html"
+        probe.unlink(missing_ok=True)
+        probe.symlink_to(SCRIPT)
+        self.addCleanup(probe.unlink, missing_ok=True)
+        with self.assertRaises(ValueError):
+            self.packaging.build_archive(VERSION)
 
     def test_archive_contains_exactly_the_distributable_kit(self) -> None:
         expected = {
@@ -89,6 +124,9 @@ class PackagingTests(unittest.TestCase):
             serve = (
                 Path(scratch) / PREFIX / "conformance" / "host-shell" / "serve.py"
             )
+            artifact_runner = (
+                Path(scratch) / PREFIX / "conformance" / "runner" / "run.py"
+            )
             server = subprocess.Popen(
                 [interpreter, str(serve), "--port", "0"],
                 stdout=subprocess.PIPE,
@@ -97,7 +135,7 @@ class PackagingTests(unittest.TestCase):
                 env={"PATH": "/usr/bin:/bin"},
             )
             try:
-                banner = server.stdout.readline()
+                banner = read_banner_line(server)
                 match = re.search(r"http://127\.0\.0\.1:(\d+)", banner)
                 self.assertIsNotNone(match, banner)
                 base_url = f"http://127.0.0.1:{match.group(1)}/fixtures"
@@ -106,7 +144,7 @@ class PackagingTests(unittest.TestCase):
                 completed = subprocess.run(
                     [
                         sys.executable,
-                        str(RUNNER),
+                        str(artifact_runner),
                         "--base-url",
                         base_url,
                         "--report-out",

--- a/tests/test_conformance_kit_packaging.py
+++ b/tests/test_conformance_kit_packaging.py
@@ -23,7 +23,7 @@ import unittest
 from pathlib import Path
 
 from tests.helpers import ROOT
-from tests.test_host_shell import non_venv_interpreter, read_banner_line
+from tests.helpers.host_process import non_venv_interpreter, read_banner_line
 
 SCRIPT = ROOT / "scripts" / "package-conformance-kit.py"
 RUN_TIMEOUT_SECONDS = 240
@@ -94,10 +94,29 @@ class PackagingTests(unittest.TestCase):
             self.packaging.build_archive(VERSION)
 
     def test_unsafe_version_values_are_rejected(self) -> None:
-        for bad in ("", "../outside", "1.0/../../x", "a\\b", "1.0..1"):
+        for bad in ("", "../outside", "1.0/../../x", "a\\b", "1.0..1", "/tmp/escape"):
             with self.subTest(version=bad):
                 with self.assertRaises(ValueError):
                     self.packaging.build_archive(bad)
+
+    def test_archive_metadata_is_normalized(self) -> None:
+        # Byte identity between two runs could agree with itself after a
+        # normalization regression; assert the contract's normalization
+        # directly instead: sorted members, fixed metadata, and a gzip
+        # header with neither an embedded mtime nor a filename.
+        names = []
+        with tarfile.open(fileobj=io.BytesIO(self.archive)) as tar:
+            for member in tar.getmembers():
+                names.append(member.name)
+                self.assertEqual(member.mtime, 0, member.name)
+                self.assertEqual(member.uid, 0, member.name)
+                self.assertEqual(member.gid, 0, member.name)
+                self.assertEqual(member.uname, "", member.name)
+                self.assertEqual(member.gname, "", member.name)
+                self.assertEqual(member.mode, 0o644, member.name)
+        self.assertEqual(names, sorted(names))
+        self.assertEqual(self.archive[4:8], b"\x00\x00\x00\x00")
+        self.assertFalse(self.archive[3] & 0x08, "gzip FNAME flag must be unset")
 
     def test_archive_contains_exactly_the_distributable_kit(self) -> None:
         expected = {

--- a/tests/test_conformance_kit_packaging.py
+++ b/tests/test_conformance_kit_packaging.py
@@ -84,11 +84,20 @@ class PackagingTests(unittest.TestCase):
 
     def test_symlinked_kit_content_is_rejected(self) -> None:
         probe = self.packaging.KIT_DIR / "fixtures" / "_symlink_probe.html"
-        probe.unlink(missing_ok=True)
+        self.assertFalse(
+            probe.exists() or probe.is_symlink(),
+            f"reserved test probe already exists: {probe}",
+        )
         probe.symlink_to(SCRIPT)
         self.addCleanup(probe.unlink, missing_ok=True)
         with self.assertRaises(ValueError):
             self.packaging.build_archive(VERSION)
+
+    def test_unsafe_version_values_are_rejected(self) -> None:
+        for bad in ("", "../outside", "1.0/../../x", "a\\b", "1.0..1"):
+            with self.subTest(version=bad):
+                with self.assertRaises(ValueError):
+                    self.packaging.build_archive(bad)
 
     def test_archive_contains_exactly_the_distributable_kit(self) -> None:
         expected = {

--- a/tests/test_conformance_kit_packaging.py
+++ b/tests/test_conformance_kit_packaging.py
@@ -1,0 +1,137 @@
+"""Deterministic packaging proof for the hash-locked conformance kit.
+
+Task 8 acceptance: two independent packaging runs produce byte-identical
+archives and identical hashes.  These tests lock that in CI, verify the
+archive carries exactly the distributable kit (no evidence snapshots, no
+test-only files), and prove an extracted artifact is self-sufficient:
+its own host shell serves it and the reference runner passes against it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import re
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.helpers import ROOT
+from tests.test_host_shell import non_venv_interpreter
+
+SCRIPT = ROOT / "scripts" / "package-conformance-kit.py"
+RUNNER = ROOT / "conformance" / "runner" / "run.py"
+RUN_TIMEOUT_SECONDS = 240
+VERSION = "1.0"
+PREFIX = f"moo-ui-conformance-kit-{VERSION}"
+
+
+def load_packaging():
+    spec = importlib.util.spec_from_file_location(
+        "package_conformance_kit", SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PackagingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.packaging = load_packaging()
+        cls.archive = cls.packaging.build_archive(VERSION)
+
+    def test_two_builds_are_byte_identical(self) -> None:
+        first = self.packaging.build_archive(VERSION)
+        second = self.packaging.build_archive(VERSION)
+        self.assertEqual(first, second)
+        self.assertEqual(
+            hashlib.sha256(first).hexdigest(),
+            hashlib.sha256(second).hexdigest(),
+        )
+
+    def test_archive_contains_exactly_the_distributable_kit(self) -> None:
+        expected = {
+            f"{PREFIX}/conformance/{path.relative_to(self.packaging.KIT_DIR).as_posix()}"
+            for path in self.packaging.kit_files()
+        }
+        with tarfile.open(fileobj=io.BytesIO(self.archive)) as tar:
+            names = {member.name for member in tar.getmembers()}
+        self.assertEqual(names, expected)
+        for forbidden in ("/reports/", "__pycache__"):
+            self.assertFalse(
+                any(forbidden in name for name in names), forbidden
+            )
+        for required in (
+            f"{PREFIX}/conformance/contract/conformance-contract.json",
+            f"{PREFIX}/conformance/contract/report.schema.json",
+            f"{PREFIX}/conformance/fixtures/static-primitives.html",
+            f"{PREFIX}/conformance/runner/run.py",
+            f"{PREFIX}/conformance/host-shell/serve.py",
+        ):
+            self.assertIn(required, names)
+
+    def test_extracted_artifact_is_self_sufficient(self) -> None:
+        interpreter = non_venv_interpreter()
+        if not interpreter:
+            raise unittest.SkipTest("no interpreter outside the .venv available")
+
+        with tempfile.TemporaryDirectory() as scratch:
+            with tarfile.open(
+                fileobj=io.BytesIO(self.archive)
+            ) as tar:
+                tar.extractall(scratch)
+            serve = (
+                Path(scratch) / PREFIX / "conformance" / "host-shell" / "serve.py"
+            )
+            server = subprocess.Popen(
+                [interpreter, str(serve), "--port", "0"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={"PATH": "/usr/bin:/bin"},
+            )
+            try:
+                banner = server.stdout.readline()
+                match = re.search(r"http://127\.0\.0\.1:(\d+)", banner)
+                self.assertIsNotNone(match, banner)
+                base_url = f"http://127.0.0.1:{match.group(1)}/fixtures"
+
+                report_path = Path(scratch) / "artifact-report.json"
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(RUNNER),
+                        "--base-url",
+                        base_url,
+                        "--report-out",
+                        str(report_path),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=RUN_TIMEOUT_SECONDS,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                report = json.loads(report_path.read_text(encoding="utf-8"))
+            finally:
+                server.terminate()
+                try:
+                    server.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    server.kill()
+                    server.wait(timeout=10)
+                server.stdout.close()
+                server.stderr.close()
+
+        self.assertEqual(report["summary"]["result"], "pass")
+        self.assertEqual(report["summary"]["assertionsFailed"], 0)
+        self.assertEqual(report["summary"]["assertionsSkipped"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_host_shell.py
+++ b/tests/test_host_shell.py
@@ -10,25 +10,21 @@ the same proof a bridge or another project would repeat.
 from __future__ import annotations
 
 import json
-import os
-import queue
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
-import threading
 import unittest
 import urllib.request
 from pathlib import Path
 
 from tests.helpers import ROOT
+from tests.helpers.host_process import non_venv_interpreter, read_banner_line
 
 SERVE = ROOT / "conformance" / "host-shell" / "serve.py"
 RUNNER = ROOT / "conformance" / "runner" / "run.py"
 CONTRACT = ROOT / "conformance" / "contract" / "conformance-contract.json"
 RUN_TIMEOUT_SECONDS = 240
-BANNER_TIMEOUT_SECONDS = 30
 ALLOWED_IMPORT_MODULES = {
     "__future__",
     "argparse",
@@ -40,21 +36,6 @@ ALLOWED_IMPORT_MODULES = {
 }
 
 
-def non_venv_interpreter() -> str:
-    """Return an interpreter outside the repository .venv, if one exists."""
-    venv_dir = os.path.realpath(str(ROOT / ".venv"))
-    for candidate in ("/usr/bin/python3", shutil.which("python3")):
-        if not candidate:
-            continue
-        resolved = os.path.realpath(candidate)
-        if not os.path.isfile(resolved):
-            continue
-        if resolved.startswith(venv_dir + os.sep):
-            continue
-        return resolved
-    return ""
-
-
 def imported_modules(source: str) -> set:
     return {
         match.group(1)
@@ -63,36 +44,6 @@ def imported_modules(source: str) -> set:
             source,
         )
     }
-
-
-def read_banner_line(server: subprocess.Popen) -> str:
-    """Read the host shell's listening-URL line with a bounded wait.
-
-    ``readline`` alone blocks until the job timeout if the host hangs
-    before printing its URL, and a readiness poll can fire on a partial
-    line.  A daemon thread performs the blocking read and hands the
-    result through a queue, so the wait stays bounded either way.
-    """
-    result = queue.Queue()
-
-    def reader() -> None:
-        try:
-            result.put(server.stdout.readline())
-        except Exception as error:
-            result.put(error)
-
-    thread = threading.Thread(target=reader, daemon=True)
-    thread.start()
-    try:
-        value = result.get(timeout=BANNER_TIMEOUT_SECONDS)
-    except queue.Empty:
-        raise AssertionError(
-            "host shell did not print its listening URL within "
-            f"{BANNER_TIMEOUT_SECONDS}s"
-        )
-    if isinstance(value, BaseException):
-        raise value
-    return value
 
 
 class HostShellTests(unittest.TestCase):

--- a/tests/test_host_shell.py
+++ b/tests/test_host_shell.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import unittest
 import urllib.request
 from pathlib import Path
@@ -26,6 +28,7 @@ SERVE = ROOT / "conformance" / "host-shell" / "serve.py"
 RUNNER = ROOT / "conformance" / "runner" / "run.py"
 CONTRACT = ROOT / "conformance" / "contract" / "conformance-contract.json"
 RUN_TIMEOUT_SECONDS = 240
+BANNER_TIMEOUT_SECONDS = 30
 ALLOWED_IMPORT_MODULES = {
     "__future__",
     "argparse",
@@ -62,6 +65,36 @@ def imported_modules(source: str) -> set:
     }
 
 
+def read_banner_line(server: subprocess.Popen) -> str:
+    """Read the host shell's listening-URL line with a bounded wait.
+
+    ``readline`` alone blocks until the job timeout if the host hangs
+    before printing its URL, and a readiness poll can fire on a partial
+    line.  A daemon thread performs the blocking read and hands the
+    result through a queue, so the wait stays bounded either way.
+    """
+    result = queue.Queue()
+
+    def reader() -> None:
+        try:
+            result.put(server.stdout.readline())
+        except Exception as error:
+            result.put(error)
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    try:
+        value = result.get(timeout=BANNER_TIMEOUT_SECONDS)
+    except queue.Empty:
+        raise AssertionError(
+            "host shell did not print its listening URL within "
+            f"{BANNER_TIMEOUT_SECONDS}s"
+        )
+    if isinstance(value, BaseException):
+        raise value
+    return value
+
+
 class HostShellTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -77,7 +110,7 @@ class HostShellTests(unittest.TestCase):
             env={"PATH": "/usr/bin:/bin"},
         )
         try:
-            banner = cls.server.stdout.readline()
+            banner = read_banner_line(cls.server)
         except Exception:
             cls.server.kill()
             raise


### PR DESCRIPTION
## Phase 5 Tasks 8-9: hash-locked conformance kit artifact + SUPPORT.md docs

Follow-up to PR #50 (Phase 5 Tasks 2-7). Four commits, all independently
verified (hash recomputation, fault injection on the symlink guard, CI
green on every commit, full local suite green on both machines).

### `3d27a98` — Task 8: hash-locked conformance kit release artifact
- `scripts/package-conformance-kit.py`: deterministic tar.gz packaging of
  the distributable kit (contract, fixtures, runner, host shell; evidence
  snapshots excluded) with a `.sha256` sidecar. Sorted members, fixed
  mtime/owner/mode, gzip with no embedded name/timestamp — byte-identical
  across interpreters and working directories (contract-1.0 SHA-256
  `f29b3e7e22273671facb4391a1da005362ea6fb9a05ccf5bdf6c827a48416c3c`).
- `npm-publish.yml` gains "Attach conformance kit artifact" right after
  release creation (tag/dispatch only, never on dev pushes; `--clobber`
  keeps retries idempotent).
- `tests/test_conformance_kit_packaging.py` locks in CI: two independent
  CLI runs byte-identical (archives + sidecars), exact archive content
  set, and extracted-artifact self-sufficiency (the artifact's own host
  shell + runner pass 62/62).

### `7c93fdb` — Task 8: address CodeRabbit findings
- Attach step builds from the tagged commit (`git checkout --detach`), so
  a `release_ref` dispatch can never attach an asset from a later commit.
- Self-sufficiency test runs the runner extracted from the artifact.
- Bounded banner reads (daemon thread + queue) in both host-shell tests.
- Symlinks rejected in kit content (regression test); determinism proven
  via two real CLI runs exercising `main()` + sidecars.

### `b7a7f79` — Task 9: SUPPORT.md documentation
"Generic Host Conformance" rewritten from the planned-status stub to the
real description: kit contents, the three-step host flow, artifact naming
+ sidecar, the reproducible contract-1.0 hash, and the GitHub Releases
pointer. No platform implementation details (forbidden-terms gate
re-verifies in CI).

### `3f1a599` — Task 8: second CodeRabbit round hardening
- `validate_version()` rejects empty/separator/traversal versions before
  they reach archive member names or `--out-dir` (5 test cases).
- Symlink-probe test fails loudly if the reserved path exists instead of
  silently deleting it.

Suite: 740 tests pass (skipped=1). No version bump, tag, or publish in
this PR; the first release carrying the artifact is the one after this
merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Published versioned conformance-kit archives and SHA-256 checksums as release assets.
  - Added deterministic packaging for reproducible, self-contained conformance kits.

- **Documentation**
  - Expanded host conformance guidance with archive contents, supported contract areas, execution steps, requirements, reports, exit codes, and verification details.

- **Tests**
  - Added coverage for archive integrity, safety, required contents, reproducibility, and standalone execution.
  - Added a timeout to prevent host startup checks from hanging indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->