### PR TITLE
Dependency updates: wrangler ^4.119.0, libsass 0.23.0, coverage 7.10.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "axe-core": "4.12.1",
-        "wrangler": "^4.112.0"
+        "wrangler": "^4.119.0"
       },
       "peerDependencies": {
         "bootstrap": ">=5.3.0 <5.4"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   },
   "devDependencies": {
     "axe-core": "4.12.1",
-    "wrangler": "^4.112.0"
+    "wrangler": "^4.119.0"
   }
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 Jinja2==3.1.6
-libsass==0.22.0
+libsass==0.23.0
 tinycss2==1.4.0
-coverage==7.6.1
+coverage==7.10.7
 playwright==1.60.0
 jsonschema==4.25.1


### PR DESCRIPTION
## Dependency updates: wrangler, libsass, coverage (manual replacement of Dependabot PRs #52/#53)

Dependabot PRs #52 (wrangler) and #53 (pip-dependencies group) went
conflicting/stale after PR #51 merged and could not be recreated (user
close blocks Dependabot's recreation), so the same updates are applied
manually through the standard dev -> main flow.

- `wrangler` floor raised to `^4.119.0` (the lock already resolved it;
  the floor now matches). Addresses the open `undici` transitive
  advisories surfaced by Dependabot security alerts.
- `libsass` 0.22.0 -> 0.23.0 and `coverage` 7.6.1 -> 7.10.7 in
  `requirements-dev.txt`. Verified locally: full suite 741 tests pass
  (skipped=1) with the new compiler — the Sass facade and all
  compilation-dependent contract tests are unaffected.
- `package-lock.json` regenerated via `npm install --package-lock-only`
  (the 0.8.1 stale-lock lesson).

Full suite: 741 tests pass locally; CI re-verifies at the PR head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling dependencies to newer versions.
  * Refreshed CSS processing and test coverage development packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->