### PR TITLE
Phase 6: 1.0.0-rc.1 prep — manifest, attestation, nightly matrix, RC rehearsal, manual acceptance

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,8 +68,10 @@ jobs:
       - name: Run browser certification matrix on ${{ matrix.browser }}
         env:
           MOO_UI_BROWSER_ENGINE: ${{ matrix.browser }}
+        # tests.test_conformance_runner is deliberately excluded: the
+        # conformance kit's runner launches Chromium by design (it certifies
+        # a reference host) and ui-ci already exercises it on every push.
         run: >
           .venv/bin/python -m unittest -v
           tests.test_certification_browser
           tests.test_datatable_browser
-          tests.test_conformance_runner

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,9 @@ jobs:
   browser-engine-matrix:
     name: browser-${{ matrix.browser }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # WebKit's GTK build is slow on hosted runners: the first real run
+    # needed over 30 minutes before completion, so give the matrix room.
+    timeout-minutes: 60
     # matrix.browser is only defined at job scope; a workflow-level group
     # would lump all engines together and cancel them against each other.
     concurrency:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,12 @@ on:
     # branch; use workflow_dispatch to exercise this matrix from any branch.
     - cron: "30 3 * * *"
   workflow_dispatch:
+  # TEMPORARY until the Phase 6 PR merges: workflows are only registered
+  # from the default branch, so this trigger lets the matrix run for real
+  # as a check on the PR itself. Remove this block before merging.
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,69 @@
+name: Nightly Certification Matrix
+
+on:
+  schedule:
+    # 03:30 UTC every day. Scheduled runs only fire from the default
+    # branch; use workflow_dispatch to exercise this matrix from any branch.
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  browser-engine-matrix:
+    name: browser-${{ matrix.browser }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # matrix.browser is only defined at job scope; a workflow-level group
+    # would lump all engines together and cancel them against each other.
+    concurrency:
+      group: nightly-matrix-${{ github.ref }}-${{ matrix.browser }}
+      cancel-in-progress: true
+    strategy:
+      # A single engine failing must not cancel the others - the point of the
+      # matrix is to surface which engines pass and which fail.
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11.5"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Create virtual environment
+        run: python -m venv .venv
+
+      - name: Install Python dependencies
+        run: .venv/bin/python -m pip install -r requirements-dev.txt
+
+      - name: Install npm development dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright ${{ matrix.browser }}
+        run: .venv/bin/python -m playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Build package and site outputs
+        run: .venv/bin/python build.py
+
+      - name: Run browser certification matrix on ${{ matrix.browser }}
+        env:
+          MOO_UI_BROWSER_ENGINE: ${{ matrix.browser }}
+        run: >
+          .venv/bin/python -m unittest -v
+          tests.test_certification_browser
+          tests.test_datatable_browser
+          tests.test_conformance_runner

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,12 +6,6 @@ on:
     # branch; use workflow_dispatch to exercise this matrix from any branch.
     - cron: "30 3 * * *"
   workflow_dispatch:
-  # TEMPORARY until the Phase 6 PR merges: workflows are only registered
-  # from the default branch, so this trigger lets the matrix run for real
-  # as a check on the PR itself. Remove this block before merging.
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/scripts/build-certification-attestation.py
+++ b/scripts/build-certification-attestation.py
@@ -49,6 +49,19 @@ def parse_args() -> argparse.Namespace:
         "--created-at",
         help="ISO-8601 timestamp; defaults to the current UTC time.",
     )
+    parser.add_argument(
+        "--limitation",
+        nargs=2,
+        metavar=("SURFACE", "DESCRIPTION"),
+        action="append",
+        default=[],
+        help=(
+            "Append an extra limitations[] entry (may be repeated). Use this "
+            "to disclose, e.g., that --browser-name did not drive a real "
+            "browser, rather than letting the browsers[] entry's required "
+            "'passed' result imply an evidence claim it cannot back."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -100,13 +113,35 @@ def resolve_head_commit() -> str:
     return completed.stdout.strip()
 
 
+def assert_worktree_is_clean() -> None:
+    completed = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(
+            "cannot inspect the checkout status; refusing to attest without "
+            f"provenance ({completed.stderr.strip()})"
+        )
+    if completed.stdout.strip():
+        raise ValueError(
+            "the checkout has uncommitted changes; refusing to attest, "
+            "since the evidence inventory is read from the working tree "
+            "and could diverge from --source-commit's committed state"
+        )
+
+
 def certified_components() -> list[dict]:
     """Every inventory component, with its evidence proven on disk.
 
     Derives each component's attested checks from its evidence profile's
     ``existing`` categories. A component whose profile is undefined, whose
-    checks fall outside the attestation contract, or whose evidence files
-    are missing raises here rather than emitting an under-reported claim.
+    tier is out of range, whose checks fall outside the attestation
+    contract, or whose evidence files are missing or escape the repository
+    raises here rather than emitting an under-reported claim.
     """
     inventory = json.loads(EVIDENCE_INVENTORY.read_text(encoding="utf-8"))
     profiles = inventory.get("profiles") or {}
@@ -119,6 +154,9 @@ def certified_components() -> list[dict]:
                 f"component {slug!r} references undefined profile "
                 f"{component.get('profile')!r}"
             )
+        tier = profile.get("tier")
+        if not isinstance(tier, int) or not 0 <= tier <= 3:
+            raise ValueError(f"component {slug!r} has an invalid tier: {tier!r}")
         checks = list(profile.get("existing") or [])
         if not checks:
             raise ValueError(
@@ -130,15 +168,29 @@ def certified_components() -> list[dict]:
                     f"component {slug!r} carries a check outside the "
                     f"attestation contract: {check!r}"
                 )
-        for evidence_path in component.get("evidence", []):
-            if not (ROOT / evidence_path).is_file():
+        evidence_paths = component.get("evidence")
+        if not isinstance(evidence_paths, list) or not evidence_paths:
+            raise ValueError(f"component {slug!r} has no evidence")
+        for evidence_path in evidence_paths:
+            if not isinstance(evidence_path, str) or not evidence_path:
+                raise ValueError(
+                    f"component {slug!r} has an invalid evidence path: "
+                    f"{evidence_path!r}"
+                )
+            resolved = (ROOT / evidence_path).resolve()
+            if ROOT.resolve() not in resolved.parents:
+                raise ValueError(
+                    f"component {slug!r} evidence escapes the repository: "
+                    f"{evidence_path}"
+                )
+            if not resolved.is_file():
                 raise ValueError(
                     f"component {slug!r} is missing evidence: {evidence_path}"
                 )
         components.append(
             {
                 "slug": slug,
-                "tier": profile["tier"],
+                "tier": tier,
                 "result": "passed",
                 "checks": checks,
             }
@@ -166,6 +218,7 @@ def build_attestation(args: argparse.Namespace) -> dict:
             "--source-commit must match the checkout HEAD: got "
             f"{args.source_commit}, checkout is at {head_commit}"
         )
+    assert_worktree_is_clean()
 
     with tarfile.open(args.package, mode="r:gz") as archive:
         package, _ = read_tarball_json(archive, "package/package.json")
@@ -203,6 +256,10 @@ def build_attestation(args: argparse.Namespace) -> dict:
             ),
         },
     ]
+    limitations.extend(
+        {"surface": surface, "description": description}
+        for surface, description in args.limitation
+    )
 
     return {
         "schemaVersion": "0.1",

--- a/scripts/build-certification-attestation.py
+++ b/scripts/build-certification-attestation.py
@@ -6,19 +6,37 @@ import argparse
 import hashlib
 import json
 import re
+import subprocess
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-PILOT_EVIDENCE = ROOT / "src/certification/pilot-evidence.json"
+EVIDENCE_INVENTORY = ROOT / "src/certification/evidence-inventory.json"
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+# The attestation schema's components[].checks enum. Every category the
+# evidence inventory reports as existing must map into this set; one that
+# does not is a contract drift we fail on loudly rather than silently drop.
+ALLOWED_CHECKS = {
+    "contract",
+    "markup",
+    "theme",
+    "rtl",
+    "responsive",
+    "keyboard",
+    "focus",
+    "lifecycle",
+    "accessibility",
+    "visual",
+    "real-device",
+    "host-conformance",
+}
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Build a Moo UI Core preview certification attestation."
+        description="Build the Core-only Moo UI release certification attestation."
     )
     parser.add_argument("--package", required=True, type=Path)
     parser.add_argument("--output", required=True, type=Path)
@@ -66,11 +84,88 @@ def normalize_created_at(value: str | None) -> str:
     return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def resolve_head_commit() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise ValueError(
+            "cannot resolve the checkout HEAD; refusing to attest without "
+            f"provenance ({completed.stderr.strip()})"
+        )
+    return completed.stdout.strip()
+
+
+def certified_components() -> list[dict]:
+    """Every inventory component, with its evidence proven on disk.
+
+    Derives each component's attested checks from its evidence profile's
+    ``existing`` categories. A component whose profile is undefined, whose
+    checks fall outside the attestation contract, or whose evidence files
+    are missing raises here rather than emitting an under-reported claim.
+    """
+    inventory = json.loads(EVIDENCE_INVENTORY.read_text(encoding="utf-8"))
+    profiles = inventory.get("profiles") or {}
+    components = []
+    for component in inventory.get("components", []):
+        slug = component.get("slug")
+        profile = profiles.get(component.get("profile"))
+        if profile is None:
+            raise ValueError(
+                f"component {slug!r} references undefined profile "
+                f"{component.get('profile')!r}"
+            )
+        checks = list(profile.get("existing") or [])
+        if not checks:
+            raise ValueError(
+                f"component {slug!r} has no existing evidence checks"
+            )
+        for check in checks:
+            if check not in ALLOWED_CHECKS:
+                raise ValueError(
+                    f"component {slug!r} carries a check outside the "
+                    f"attestation contract: {check!r}"
+                )
+        for evidence_path in component.get("evidence", []):
+            if not (ROOT / evidence_path).is_file():
+                raise ValueError(
+                    f"component {slug!r} is missing evidence: {evidence_path}"
+                )
+        components.append(
+            {
+                "slug": slug,
+                "tier": profile["tier"],
+                "result": "passed",
+                "checks": checks,
+            }
+        )
+    if not components:
+        raise ValueError("evidence inventory lists no components")
+    return components
+
+
 def build_attestation(args: argparse.Namespace) -> dict:
     if not args.package.is_file():
         raise ValueError(f"Package tarball does not exist: {args.package}")
     if not COMMIT_PATTERN.fullmatch(args.source_commit):
         raise ValueError("--source-commit must be a 40-character lowercase Git commit")
+
+    # The evidence inventory (and the evidence files it references) is read
+    # from the working checkout, not from the tarball — it is not shipped in
+    # the package. Pin that evidence to the claimed commit: the checkout must
+    # actually be at --source-commit, otherwise a caller could attest one
+    # tarball with evidence drawn from a different checkout.
+    head_commit = resolve_head_commit()
+    if head_commit != args.source_commit:
+        raise ValueError(
+            "the evidence inventory is read from the working checkout, so "
+            "--source-commit must match the checkout HEAD: got "
+            f"{args.source_commit}, checkout is at {head_commit}"
+        )
 
     with tarfile.open(args.package, mode="r:gz") as archive:
         package, _ = read_tarball_json(archive, "package/package.json")
@@ -84,40 +179,35 @@ def build_attestation(args: argparse.Namespace) -> dict:
     if package["version"] != manifest["coreVersion"]:
         raise ValueError("Package and certification Core versions do not match")
     if manifest["status"] != "preview":
-        raise ValueError("Phase 0 generator accepts preview manifests only")
+        raise ValueError(
+            "This rehearsal generator accepts preview manifests only"
+        )
 
-    pilot = json.loads(PILOT_EVIDENCE.read_text(encoding="utf-8"))
-    preview_components = [
-        component
-        for component in pilot["components"]
-        if component["status"] == "preview-passed"
-    ]
-    if len(preview_components) != 5:
-        raise ValueError("Phase 0 preview requires all five pilot components")
+    components = certified_components()
 
     limitations = [
         {
-            "surface": component["slug"],
-            "description": limitation,
-        }
-        for component in preview_components
-        for limitation in component["limitations"]
-    ]
-    limitations.insert(
-        0,
-        {
             "surface": "release",
             "description": (
-                "This is Phase 0 preview evidence, not a complete release "
-                "certification claim."
+                "Automated Core-only evidence for a release candidate; "
+                "real-device and manual accessibility acceptance are "
+                "recorded separately before final certification."
             ),
         },
-    )
+        {
+            "surface": "browsers",
+            "description": (
+                "This attestation records the single automated browser run "
+                "supplied by the caller; the full cross-browser matrix is "
+                "tracked by the nightly certification workflow."
+            ),
+        },
+    ]
 
     return {
         "schemaVersion": "0.1",
         "status": "preview",
-        "scope": "phase-0-pilot",
+        "scope": "core",
         "coreVersion": package["version"],
         "sourceCommit": args.source_commit,
         "createdAt": normalize_created_at(args.created_at),
@@ -147,19 +237,10 @@ def build_attestation(args: argparse.Namespace) -> dict:
                 "evidence": args.automated_evidence,
             }
         ],
-        "components": [
-            {
-                "slug": component["slug"],
-                "tier": component["tier"],
-                "result": "passed",
-                "checks": component["evidence"]["existing"],
-                "evidence": [args.automated_evidence],
-            }
-            for component in preview_components
-        ],
+        "components": components,
         "automatedRuns": [
             {
-                "name": "phase-0-pilot",
+                "name": "core-certification",
                 "result": "passed",
                 "evidence": args.automated_evidence,
             }

--- a/scripts/build-certification-attestation.py
+++ b/scripts/build-certification-attestation.py
@@ -14,24 +14,26 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 EVIDENCE_INVENTORY = ROOT / "src/certification/evidence-inventory.json"
+ATTESTATION_SCHEMA = ROOT / "src/certification/attestation.schema.json"
 COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
-# The attestation schema's components[].checks enum. Every category the
-# evidence inventory reports as existing must map into this set; one that
-# does not is a contract drift we fail on loudly rather than silently drop.
-ALLOWED_CHECKS = {
-    "contract",
-    "markup",
-    "theme",
-    "rtl",
-    "responsive",
-    "keyboard",
-    "focus",
-    "lifecycle",
-    "accessibility",
-    "visual",
-    "real-device",
-    "host-conformance",
-}
+GIT_TIMEOUT_SECONDS = 60
+
+
+def allowed_checks() -> set[str]:
+    """The attestation schema's components[].checks enum, read from the
+    schema itself so this generator cannot drift from the contract it
+    validates against. Every category the evidence inventory reports as
+    existing must map into this set; one that does not is a contract drift
+    we fail on loudly rather than silently drop."""
+    schema = json.loads(ATTESTATION_SCHEMA.read_text(encoding="utf-8"))
+    return set(
+        schema["properties"]["components"]["items"]["properties"]["checks"][
+            "items"
+        ]["enum"]
+    )
+
+
+ALLOWED_CHECKS = allowed_checks()
 
 
 def parse_args() -> argparse.Namespace:
@@ -104,6 +106,7 @@ def resolve_head_commit() -> str:
         check=False,
         capture_output=True,
         text=True,
+        timeout=GIT_TIMEOUT_SECONDS,
     )
     if completed.returncode != 0:
         raise ValueError(
@@ -120,6 +123,7 @@ def assert_worktree_is_clean() -> None:
         check=False,
         capture_output=True,
         text=True,
+        timeout=GIT_TIMEOUT_SECONDS,
     )
     if completed.returncode != 0:
         raise ValueError(

--- a/scripts/build-certification-manifest.py
+++ b/scripts/build-certification-manifest.py
@@ -10,9 +10,11 @@ instead of producing a manifest that silently under-reports.
 
 The generator never upgrades claims on its own: ``--status preview`` (the
 default) emits the rehearsal manifest; ``--status certified`` additionally
-requires ``--source-commit`` and ``--attestation`` and refuses to run
-unless the shipped certification data already carries a verified Bootstrap
-range.
+requires ``--source-commit``, ``--attestation``, ``--attestation-file``,
+and ``--attestation-sha256`` (binding the embedded URI to the validated
+file's own hash), and refuses to run unless the referenced attestation is
+itself certified and passing, and the shipped certification data already
+carries a verified Bootstrap range.
 
 Usage:
     python scripts/build-certification-manifest.py \
@@ -70,7 +72,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--attestation",
         help="Public URI of the release attestation (certified only). This "
-        "is embedded as metadata; --attestation-file is what gets validated.",
+        "is embedded as metadata; --attestation-file is what gets validated, "
+        "and --attestation-sha256 binds the two together.",
     )
     parser.add_argument(
         "--attestation-file",
@@ -79,6 +82,13 @@ def parse_args() -> argparse.Namespace:
         "Validated against attestation.schema.json and cross-checked "
         "against this manifest's own coreVersion, sourceCommit, and "
         "package hash before certified status is emitted.",
+    )
+    parser.add_argument(
+        "--attestation-sha256",
+        help="SHA-256 of the exact bytes served at --attestation (certified "
+        "only). Required so the embedded URI cannot silently diverge from "
+        "the validated --attestation-file: this generator checks the file's "
+        "own hash against it, not just its content.",
     )
     parser.add_argument(
         "--expected-package-sha256",
@@ -101,22 +111,38 @@ def certified_attestation(
     source_commit: str,
     core_version: str,
     package_sha256: str,
+    expected_attestation_sha256: str,
 ) -> dict:
     """Load and validate the attestation backing a certified manifest.
 
     A certified manifest's --attestation is only a public URI pointer; on
-    its own that proves nothing. This loads the actual attestation document,
-    validates it against its schema, and refuses certified status unless its
-    own status is "certified" (a preview attestation cannot back a certified
-    manifest, even a passing one) and its sourceCommit, coreVersion, package
-    hash, and result all agree with what this manifest run has independently
-    established.
+    its own that proves nothing, and validating --attestation-file alone
+    does not bind that validated content to the URI actually embedded in
+    the manifest - a caller could validate one document and publish a URI
+    for different evidence. --attestation-sha256 closes that gap: it is
+    the hash the caller claims --attestation serves, checked here against
+    the actual bytes of --attestation-file.
+
+    This also validates the document against its schema, and refuses
+    certified status unless its own status is "certified" (a preview
+    attestation cannot back a certified manifest, even a passing one) and
+    its sourceCommit, coreVersion, package hash, and result all agree with
+    what this manifest run has independently established.
     """
     if not attestation_file.is_file():
         raise ValueError(
             f"--attestation-file does not exist: {attestation_file}"
         )
-    attestation = json.loads(attestation_file.read_text(encoding="utf-8"))
+    attestation_bytes = attestation_file.read_bytes()
+    actual_attestation_sha256 = hashlib.sha256(attestation_bytes).hexdigest()
+    if actual_attestation_sha256 != expected_attestation_sha256.lower():
+        raise ValueError(
+            "--attestation-sha256 does not match --attestation-file: "
+            f"expected {expected_attestation_sha256}, got "
+            f"{actual_attestation_sha256}. The embedded --attestation URI "
+            "must point at exactly this file's bytes."
+        )
+    attestation = json.loads(attestation_bytes.decode("utf-8"))
 
     validator = Draft202012Validator(load_attestation_schema())
     errors = sorted(validator.iter_errors(attestation), key=str)
@@ -288,11 +314,18 @@ def build_manifest(args: argparse.Namespace) -> dict:
                 "--attestation-file is required for a certified manifest; "
                 "--attestation alone is an unvalidated pointer"
             )
+        if not args.attestation_sha256:
+            raise ValueError(
+                "--attestation-sha256 is required for a certified manifest; "
+                "without it, --attestation could name different evidence "
+                "than --attestation-file validated"
+            )
         certified_attestation(
             args.attestation_file,
             source_commit=args.source_commit,
             core_version=package["version"],
             package_sha256=package_sha256,
+            expected_attestation_sha256=args.attestation_sha256,
         )
         if not bootstrap.get("verifiedRange"):
             raise ValueError(

--- a/scripts/build-certification-manifest.py
+++ b/scripts/build-certification-manifest.py
@@ -106,9 +106,11 @@ def certified_attestation(
 
     A certified manifest's --attestation is only a public URI pointer; on
     its own that proves nothing. This loads the actual attestation document,
-    validates it against its schema, and refuses certified status unless
-    its sourceCommit, coreVersion, package hash, and result all agree with
-    what this manifest run has independently established.
+    validates it against its schema, and refuses certified status unless its
+    own status is "certified" (a preview attestation cannot back a certified
+    manifest, even a passing one) and its sourceCommit, coreVersion, package
+    hash, and result all agree with what this manifest run has independently
+    established.
     """
     if not attestation_file.is_file():
         raise ValueError(
@@ -124,6 +126,12 @@ def certified_attestation(
             + "; ".join(error.message for error in errors)
         )
 
+    if attestation.get("status") != "certified":
+        raise ValueError(
+            "attestation status is "
+            f"{attestation.get('status')!r}, not 'certified'; a preview "
+            "attestation cannot back a certified manifest"
+        )
     if attestation.get("result") != "passed":
         raise ValueError(
             "attestation does not record a passing result; refusing to "

--- a/scripts/build-certification-manifest.py
+++ b/scripts/build-certification-manifest.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Generate the Core-only certification manifest for a Moo UI release.
+
+Produces a document conforming to ``src/certification/manifest.schema.json``
+from the current evidence inventory plus the built npm tarball itself:
+the Core version and Bootstrap facts are read from inside the tarball (the
+same ``certification.json`` that ships in it), and every component listed
+must carry real, on-disk evidence — a missing evidence file fails loudly
+instead of producing a manifest that silently under-reports.
+
+The generator never upgrades claims on its own: ``--status preview`` (the
+default) emits the rehearsal manifest; ``--status certified`` additionally
+requires ``--source-commit`` and ``--attestation`` and refuses to run
+unless the shipped certification data already carries a verified Bootstrap
+range.
+
+Usage:
+    python scripts/build-certification-manifest.py \
+        --package dist/wpmoo-ui-0.9.0.tgz --output dist/certification-manifest.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tarfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_SCHEMA_VERSION = "1.0"
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+SUPPORT_POLICY_URL = "https://github.com/wpmoo-org/ui/blob/main/SUPPORT.md"
+PREVIEW_BROWSER_POLICY = (
+    "Certification is in progress; see SUPPORT.md for the intended browser "
+    "policy."
+)
+CERTIFIED_BROWSER_POLICY = (
+    "Modern browsers per SUPPORT.md (current and previous stable Chrome, "
+    "Edge, Firefox, macOS Safari, and iOS Safari majors, plus current "
+    "stable Android Chrome); the attestation records the exact browser "
+    "and operating-system versions actually tested."
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build the Core-only certification manifest."
+    )
+    parser.add_argument("--package", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=ROOT / "src/certification/evidence-inventory.json",
+        help="Evidence inventory to certify from.",
+    )
+    parser.add_argument(
+        "--status",
+        choices=("preview", "certified"),
+        default="preview",
+        help="Preview is the rehearsal default; certified requires the "
+        "release attestation inputs below.",
+    )
+    parser.add_argument("--source-commit")
+    parser.add_argument(
+        "--attestation",
+        help="Public URI of the release attestation (certified only).",
+    )
+    parser.add_argument(
+        "--expected-package-sha256",
+        help="When given, the tarball's hash must match exactly.",
+    )
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_tarball_json(archive: tarfile.TarFile, member_name: str) -> dict:
+    member = archive.getmember(member_name)
+    if not member.isfile():
+        raise ValueError(f"Tarball member is not a file: {member_name}")
+    stream = archive.extractfile(member)
+    if stream is None:
+        raise ValueError(f"Tarball member cannot be read: {member_name}")
+    return json.loads(stream.read().decode("utf-8"))
+
+
+def load_inventory(path: Path) -> dict:
+    if not path.is_file():
+        raise ValueError(f"evidence inventory does not exist: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def certified_components(inventory: dict) -> list[dict]:
+    """Every inventory component, with its evidence proven on disk.
+
+    A component whose profile is undefined, whose tier is out of range,
+    or whose evidence files are missing raises here — the manifest must
+    never list a component whose evidence cannot be produced.
+    """
+    profiles = inventory.get("profiles") or {}
+    components = []
+    for component in inventory.get("components", []):
+        slug = component.get("slug")
+        profile = profiles.get(component.get("profile"))
+        if profile is None:
+            raise ValueError(
+                f"component {slug!r} references undefined profile "
+                f"{component.get('profile')!r}"
+            )
+        tier = profile.get("tier")
+        if not isinstance(tier, int) or not 0 <= tier <= 3:
+            raise ValueError(f"component {slug!r} has an invalid tier: {tier!r}")
+        evidence_paths = component.get("evidence")
+        if not isinstance(evidence_paths, list) or not evidence_paths:
+            raise ValueError(f"component {slug!r} has no evidence")
+        for evidence_path in evidence_paths:
+            if not isinstance(evidence_path, str) or not evidence_path:
+                raise ValueError(
+                    f"component {slug!r} has an invalid evidence path: "
+                    f"{evidence_path!r}"
+                )
+            resolved = (ROOT / evidence_path).resolve()
+            if ROOT.resolve() not in resolved.parents:
+                raise ValueError(
+                    f"component {slug!r} evidence escapes the repository: "
+                    f"{evidence_path}"
+                )
+            if not resolved.is_file():
+                raise ValueError(
+                    f"component {slug!r} is missing evidence: {evidence_path}"
+                )
+        components.append({"slug": slug, "tier": tier, "status": "certified"})
+    if not components:
+        raise ValueError("evidence inventory lists no components")
+    return components
+
+
+def build_manifest(args: argparse.Namespace) -> dict:
+    if not args.package.is_file():
+        raise ValueError(f"package tarball does not exist: {args.package}")
+
+    package_sha256 = sha256_file(args.package)
+    if args.expected_package_sha256:
+        if package_sha256 != args.expected_package_sha256.lower():
+            raise ValueError(
+                "package hash mismatch: expected "
+                f"{args.expected_package_sha256}, got {package_sha256}"
+            )
+
+    with tarfile.open(args.package, mode="r:gz") as archive:
+        package = read_tarball_json(archive, "package/package.json")
+        certification = read_tarball_json(archive, "package/certification.json")
+
+    if package.get("name") != "@wpmoo/ui":
+        raise ValueError("Tarball is not the canonical @wpmoo/ui package")
+    if package.get("version") != certification.get("coreVersion"):
+        raise ValueError("Package and certification Core versions do not match")
+
+    bootstrap = certification.get("bootstrap") or {}
+    target_range = (package.get("peerDependencies") or {}).get("bootstrap")
+    if target_range != bootstrap.get("targetRange"):
+        raise ValueError(
+            "peerDependencies bootstrap range does not match the shipped "
+            f"certification: {target_range!r} vs {bootstrap.get('targetRange')!r}"
+        )
+
+    components = certified_components(load_inventory(args.inventory))
+
+    manifest = {
+        "schemaVersion": MANIFEST_SCHEMA_VERSION,
+        "status": args.status,
+        "coreVersion": package["version"],
+        "bootstrap": {
+            "canonicalVersion": bootstrap["canonicalVersion"],
+            "targetRange": bootstrap["targetRange"],
+            "verifiedRange": bootstrap.get("verifiedRange"),
+            "testedVersions": bootstrap.get("testedVersions", []),
+        },
+        "browserPolicy": {
+            "policy": PREVIEW_BROWSER_POLICY,
+            "exactEvidenceInAttestation": False,
+        },
+        "certifiedComponents": components,
+        "publicEntrypoints": certification["publicEntrypoints"],
+        "supportPolicy": SUPPORT_POLICY_URL,
+    }
+
+    if args.status == "certified":
+        if not args.source_commit or not COMMIT_PATTERN.fullmatch(args.source_commit):
+            raise ValueError(
+                "--source-commit must be a 40-character lowercase Git commit "
+                "for a certified manifest"
+            )
+        if not args.attestation:
+            raise ValueError("--attestation URI is required for a certified manifest")
+        if not bootstrap.get("verifiedRange"):
+            raise ValueError(
+                "shipped certification carries no verified Bootstrap range; "
+                "refusing to claim certified status"
+            )
+        manifest["sourceCommit"] = args.source_commit
+        manifest["attestation"] = args.attestation
+        manifest["browserPolicy"] = {
+            "policy": CERTIFIED_BROWSER_POLICY,
+            "exactEvidenceInAttestation": True,
+        }
+
+    return manifest
+
+
+def main() -> None:
+    args = parse_args()
+    if args.package.resolve() == args.output.resolve():
+        raise ValueError(
+            "--output must not name the package tarball; refusing to "
+            "overwrite the release artifact"
+        )
+    manifest = build_manifest(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(manifest, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"{sha256_file(args.output)}  {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build-certification-manifest.py
+++ b/scripts/build-certification-manifest.py
@@ -320,13 +320,31 @@ def build_manifest(args: argparse.Namespace) -> dict:
                 "without it, --attestation could name different evidence "
                 "than --attestation-file validated"
             )
-        certified_attestation(
+        attestation = certified_attestation(
             args.attestation_file,
             source_commit=args.source_commit,
             core_version=package["version"],
             package_sha256=package_sha256,
             expected_attestation_sha256=args.attestation_sha256,
         )
+        attested_components = {
+            component.get("slug"): component
+            for component in attestation.get("components", [])
+        }
+        for component in components:
+            slug = component["slug"]
+            attested = attested_components.get(slug)
+            if attested is None:
+                raise ValueError(
+                    f"component {slug!r} is in certifiedComponents but has "
+                    "no matching entry in the attestation's components[]"
+                )
+            if attested.get("result") != "passed":
+                raise ValueError(
+                    f"component {slug!r} is in certifiedComponents but the "
+                    f"attestation records its result as "
+                    f"{attested.get('result')!r}, not 'passed'"
+                )
         if not bootstrap.get("verifiedRange"):
             raise ValueError(
                 "shipped certification carries no verified Bootstrap range; "

--- a/scripts/build-certification-manifest.py
+++ b/scripts/build-certification-manifest.py
@@ -28,6 +28,8 @@ import re
 import tarfile
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 
 ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_SCHEMA_VERSION = "1.0"
@@ -67,13 +69,83 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--source-commit")
     parser.add_argument(
         "--attestation",
-        help="Public URI of the release attestation (certified only).",
+        help="Public URI of the release attestation (certified only). This "
+        "is embedded as metadata; --attestation-file is what gets validated.",
+    )
+    parser.add_argument(
+        "--attestation-file",
+        type=Path,
+        help="Local path to the release attestation JSON (certified only). "
+        "Validated against attestation.schema.json and cross-checked "
+        "against this manifest's own coreVersion, sourceCommit, and "
+        "package hash before certified status is emitted.",
     )
     parser.add_argument(
         "--expected-package-sha256",
         help="When given, the tarball's hash must match exactly.",
     )
     return parser.parse_args()
+
+
+def load_attestation_schema() -> dict:
+    return json.loads(
+        (ROOT / "src/certification/attestation.schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+
+def certified_attestation(
+    attestation_file: Path,
+    *,
+    source_commit: str,
+    core_version: str,
+    package_sha256: str,
+) -> dict:
+    """Load and validate the attestation backing a certified manifest.
+
+    A certified manifest's --attestation is only a public URI pointer; on
+    its own that proves nothing. This loads the actual attestation document,
+    validates it against its schema, and refuses certified status unless
+    its sourceCommit, coreVersion, package hash, and result all agree with
+    what this manifest run has independently established.
+    """
+    if not attestation_file.is_file():
+        raise ValueError(
+            f"--attestation-file does not exist: {attestation_file}"
+        )
+    attestation = json.loads(attestation_file.read_text(encoding="utf-8"))
+
+    validator = Draft202012Validator(load_attestation_schema())
+    errors = sorted(validator.iter_errors(attestation), key=str)
+    if errors:
+        raise ValueError(
+            "attestation file does not conform to attestation.schema.json: "
+            + "; ".join(error.message for error in errors)
+        )
+
+    if attestation.get("result") != "passed":
+        raise ValueError(
+            "attestation does not record a passing result; refusing to "
+            "claim certified status"
+        )
+    if attestation.get("sourceCommit") != source_commit:
+        raise ValueError(
+            "attestation sourceCommit does not match --source-commit: "
+            f"{attestation.get('sourceCommit')!r} vs {source_commit!r}"
+        )
+    if attestation.get("coreVersion") != core_version:
+        raise ValueError(
+            "attestation coreVersion does not match the package tarball: "
+            f"{attestation.get('coreVersion')!r} vs {core_version!r}"
+        )
+    attested_package_sha256 = (attestation.get("package") or {}).get("sha256")
+    if attested_package_sha256 != package_sha256:
+        raise ValueError(
+            "attestation package hash does not match the package tarball: "
+            f"{attested_package_sha256!r} vs {package_sha256!r}"
+        )
+    return attestation
 
 
 def sha256_file(path: Path) -> str:
@@ -203,6 +275,17 @@ def build_manifest(args: argparse.Namespace) -> dict:
             )
         if not args.attestation:
             raise ValueError("--attestation URI is required for a certified manifest")
+        if not args.attestation_file:
+            raise ValueError(
+                "--attestation-file is required for a certified manifest; "
+                "--attestation alone is an unvalidated pointer"
+            )
+        certified_attestation(
+            args.attestation_file,
+            source_commit=args.source_commit,
+            core_version=package["version"],
+            package_sha256=package_sha256,
+        )
         if not bootstrap.get("verifiedRange"):
             raise ValueError(
                 "shipped certification carries no verified Bootstrap range; "

--- a/scripts/rehearse-rc.py
+++ b/scripts/rehearse-rc.py
@@ -141,19 +141,40 @@ def step_conformance_kit() -> Path:
     return archive
 
 
-def step_manifest_and_attestation() -> list:
-    print("== certification manifest + attestation (Phase 6 Tasks 1/2) ==")
-    collected = []
-    for label, script in (
-        ("manifest", MANIFEST_SCRIPT),
-        ("attestation", ATTESTATION_SCRIPT),
-    ):
-        if not script.is_file():
-            print(f"{label}: pending — {script.name} does not exist yet")
-            continue
-        print(f"{label}: {script.name} exists, but Stage B wiring is not implemented yet")
-        collected.append(script)
-    return collected
+def step_manifest(tarball: Path) -> Path | None:
+    print("== certification manifest (Phase 6 Task 1) ==")
+    if not MANIFEST_SCRIPT.is_file():
+        print(f"pending — {MANIFEST_SCRIPT.name} does not exist yet")
+        return None
+    manifest_path = OUT_DIR / "certification-manifest.json"
+    run(
+        [
+            sys.executable,
+            str(MANIFEST_SCRIPT),
+            "--package",
+            str(tarball),
+            "--output",
+            str(manifest_path),
+            "--status",
+            "preview",
+        ]
+    )
+    print(f"{manifest_path} ({sha256_of(manifest_path)})")
+    return manifest_path
+
+
+def step_attestation() -> Path | None:
+    print("== release attestation (Phase 6 Task 2) ==")
+    # Task 2 re-scopes this generator from pilot-evidence.json to the
+    # current Core-only evidence inventory; wiring it in before that
+    # lands would produce a preview manifest built from stale pilot-era
+    # claims, which is worse than reporting it as not ready yet.
+    print(
+        f"pending — {ATTESTATION_SCRIPT.name} exists but still reads "
+        "pilot-evidence.json (Task 2 not landed yet); not wired in until "
+        "it's re-scoped to Core-only evidence"
+    )
+    return None
 
 
 def main() -> int:
@@ -163,7 +184,8 @@ def main() -> int:
         step_install_and_smoke()
         tarball = step_collect_tarball()
         kit_archive = step_conformance_kit()
-        pending = step_manifest_and_attestation()
+        manifest = step_manifest(tarball)
+        attestation = step_attestation()
     except RehearsalError as error:
         print(f"\nREHEARSAL FAILED: {error}", file=sys.stderr)
         return 1
@@ -173,16 +195,14 @@ def main() -> int:
     print(f"source commit:   {source_commit()}")
     print(f"tarball:         {tarball} ({sha256_of(tarball)})")
     print(f"conformance kit: {kit_archive} ({sha256_of(kit_archive)})")
-    if pending:
-        print(
-            "Stage B (manifest/attestation) not wired in yet — "
-            f"{len(pending)} generator script(s) present but not integrated."
-        )
+    if manifest:
+        print(f"manifest:        {manifest} ({sha256_of(manifest)})")
     else:
-        print(
-            "Stage B (manifest/attestation) generators not found — "
-            "waiting on Phase 6 Tasks 1/2."
-        )
+        print("manifest:        pending (Phase 6 Task 1)")
+    if attestation:
+        print(f"attestation:     {attestation} ({sha256_of(attestation)})")
+    else:
+        print("attestation:     pending (Phase 6 Task 2)")
     print("\nREHEARSAL OK (no publish, no tag)")
     return 0
 

--- a/scripts/rehearse-rc.py
+++ b/scripts/rehearse-rc.py
@@ -3,12 +3,11 @@
 
 Mirrors `npm-publish.yml`'s real build/pack steps (catalog build, package
 boundary check, the tested install-and-smoke sequence) and collects every
-RC-required artifact — the npm tarball, the conformance-kit archive, and
-(once Phase 6 Tasks 1/2 land) the certification manifest and release
-attestation — into `dist/rc-rehearsal/`, printing their versions, source
-commit, and hashes so a human can confirm they agree before cutting a real
-RC. Exits non-zero on any failure; never runs `npm publish`, `npm version`,
-or creates a tag.
+RC-required artifact — the npm tarball, the conformance-kit archive, the
+certification manifest, and the release attestation — into
+`dist/rc-rehearsal/`, printing their versions, source commit, and hashes so
+a human can confirm they agree before cutting a real RC. Exits non-zero on
+any failure; never runs `npm publish`, `npm version`, or creates a tag.
 
 Usage:
     python scripts/rehearse-rc.py
@@ -27,9 +26,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 OUT_DIR = ROOT / "dist" / "rc-rehearsal"
+DEFAULT_TIMEOUT_SECONDS = 600
 
-# Stage B (Phase 6 Tasks 1/2) drop their generators here once they land;
-# Stage A runs standalone and reports them as pending until then.
 MANIFEST_SCRIPT = ROOT / "scripts" / "build-certification-manifest.py"
 ATTESTATION_SCRIPT = ROOT / "scripts" / "build-certification-attestation.py"
 
@@ -39,8 +37,9 @@ class RehearsalError(RuntimeError):
 
 
 def run(cmd: list, **kwargs) -> subprocess.CompletedProcess:
+    kwargs.setdefault("timeout", DEFAULT_TIMEOUT_SECONDS)
     result = subprocess.run(
-        cmd, cwd=ROOT, capture_output=True, text=True, **kwargs
+        cmd, cwd=ROOT, check=False, capture_output=True, text=True, **kwargs
     )
     if result.returncode != 0:
         raise RehearsalError(
@@ -55,6 +54,20 @@ def sha256_of(path: Path) -> str:
 
 def source_commit() -> str:
     return run(["git", "rev-parse", "HEAD"]).stdout.strip()
+
+
+def assert_worktree_is_clean() -> None:
+    # step_attestation's own generator refuses a dirty worktree too (the
+    # evidence inventory it reads is not pinned to the commit it claims
+    # otherwise); checking here as well means a dirty tree fails before the
+    # full build/pack/install cycle runs, not after it.
+    status = run(["git", "status", "--porcelain"]).stdout
+    if status.strip():
+        raise RehearsalError(
+            "the checkout has uncommitted changes; the attestation step "
+            "will refuse to run against a dirty worktree, so failing here "
+            "instead of after the full rehearsal"
+        )
 
 
 def package_version() -> str:
@@ -89,10 +102,14 @@ def step_install_and_smoke() -> None:
             sys.executable,
             "-m",
             "unittest",
-            "tests.test_package.PackageMetadataTests."
-            "test_real_tarball_resolves_from_a_clean_consumer",
-            "tests.test_package.PackageMetadataTests."
-            "test_sass_facade_compiles_from_a_clean_consumer",
+            (
+                "tests.test_package.PackageMetadataTests."
+                "test_real_tarball_resolves_from_a_clean_consumer"
+            ),
+            (
+                "tests.test_package.PackageMetadataTests."
+                "test_sass_facade_compiles_from_a_clean_consumer"
+            ),
             "-v",
         ]
     )
@@ -144,11 +161,8 @@ def step_conformance_kit() -> Path:
     return archive
 
 
-def step_manifest(tarball: Path) -> Path | None:
-    print("== certification manifest (Phase 6 Task 1) ==")
-    if not MANIFEST_SCRIPT.is_file():
-        print(f"pending — {MANIFEST_SCRIPT.name} does not exist yet")
-        return None
+def step_manifest(tarball: Path) -> Path:
+    print("== certification manifest ==")
     manifest_path = OUT_DIR / "certification-manifest.json"
     run(
         [
@@ -177,8 +191,8 @@ def evidence_uri() -> str:
     return "urn:rehearsal:local-run"
 
 
-def step_attestation(tarball: Path, commit: str) -> Path | None:
-    print("== release attestation (Phase 6 Task 2) ==")
+def step_attestation(tarball: Path, commit: str) -> Path:
+    print("== release attestation ==")
     attestation_path = OUT_DIR / "certification-attestation.json"
     # Rehearsal-honest values: no browser was actually driven by this
     # script, so the attestation says so rather than claiming a real
@@ -219,13 +233,14 @@ def step_attestation(tarball: Path, commit: str) -> Path | None:
 
 def main() -> int:
     try:
+        commit = source_commit()
+        assert_worktree_is_clean()
         step_build_catalog()
         step_verify_package_boundary()
         step_install_and_smoke()
         tarball = step_collect_tarball()
         kit_archive = step_conformance_kit()
         manifest = step_manifest(tarball)
-        commit = source_commit()
         attestation = step_attestation(tarball, commit)
     except RehearsalError as error:
         print(f"\nREHEARSAL FAILED: {error}", file=sys.stderr)
@@ -236,14 +251,8 @@ def main() -> int:
     print(f"source commit:   {commit}")
     print(f"tarball:         {tarball} ({sha256_of(tarball)})")
     print(f"conformance kit: {kit_archive} ({sha256_of(kit_archive)})")
-    if manifest:
-        print(f"manifest:        {manifest} ({sha256_of(manifest)})")
-    else:
-        print("manifest:        pending (Phase 6 Task 1)")
-    if attestation:
-        print(f"attestation:     {attestation} ({sha256_of(attestation)})")
-    else:
-        print("attestation:     pending (Phase 6 Task 2)")
+    print(f"manifest:        {manifest} ({sha256_of(manifest)})")
+    print(f"attestation:     {attestation} ({sha256_of(attestation)})")
     print("\nREHEARSAL OK (no publish, no tag)")
     return 0
 

--- a/scripts/rehearse-rc.py
+++ b/scripts/rehearse-rc.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -163,18 +165,46 @@ def step_manifest(tarball: Path) -> Path | None:
     return manifest_path
 
 
-def step_attestation() -> Path | None:
+def evidence_uri() -> str:
+    """A real CI run URL when running in GitHub Actions, otherwise an
+    honest local marker — never a fabricated evidence link."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        server = os.environ["GITHUB_SERVER_URL"]
+        repo = os.environ["GITHUB_REPOSITORY"]
+        run_id = os.environ["GITHUB_RUN_ID"]
+        return f"{server}/{repo}/actions/runs/{run_id}"
+    return "urn:rehearsal:local-run"
+
+
+def step_attestation(tarball: Path, commit: str) -> Path | None:
     print("== release attestation (Phase 6 Task 2) ==")
-    # Task 2 re-scopes this generator from pilot-evidence.json to the
-    # current Core-only evidence inventory; wiring it in before that
-    # lands would produce a preview manifest built from stale pilot-era
-    # claims, which is worse than reporting it as not ready yet.
-    print(
-        f"pending — {ATTESTATION_SCRIPT.name} exists but still reads "
-        "pilot-evidence.json (Task 2 not landed yet); not wired in until "
-        "it's re-scoped to Core-only evidence"
+    attestation_path = OUT_DIR / "certification-attestation.json"
+    # Rehearsal-honest values: no browser was actually driven by this
+    # script, so the attestation says so rather than claiming a real
+    # cross-browser run. The real automated evidence is ui-ci.yml's own
+    # Chromium contract-test run, tracked separately.
+    run(
+        [
+            sys.executable,
+            str(ATTESTATION_SCRIPT),
+            "--package",
+            str(tarball),
+            "--output",
+            str(attestation_path),
+            "--source-commit",
+            commit,
+            "--browser-name",
+            "rehearsal",
+            "--browser-version",
+            "n/a",
+            "--operating-system",
+            platform.platform(),
+            "--automated-evidence",
+            evidence_uri(),
+        ]
     )
-    return None
+    print(f"{attestation_path} ({sha256_of(attestation_path)})")
+    return attestation_path
 
 
 def main() -> int:
@@ -185,14 +215,15 @@ def main() -> int:
         tarball = step_collect_tarball()
         kit_archive = step_conformance_kit()
         manifest = step_manifest(tarball)
-        attestation = step_attestation()
+        commit = source_commit()
+        attestation = step_attestation(tarball, commit)
     except RehearsalError as error:
         print(f"\nREHEARSAL FAILED: {error}", file=sys.stderr)
         return 1
 
     print("\n== summary ==")
     print(f"package version: {package_version()}")
-    print(f"source commit:   {source_commit()}")
+    print(f"source commit:   {commit}")
     print(f"tarball:         {tarball} ({sha256_of(tarball)})")
     print(f"conformance kit: {kit_archive} ({sha256_of(kit_archive)})")
     if manifest:

--- a/scripts/rehearse-rc.py
+++ b/scripts/rehearse-rc.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Rehearse a `1.0.0-rc.1`-style release without publishing or tagging.
+
+Mirrors `npm-publish.yml`'s real build/pack steps (catalog build, package
+boundary check, the tested install-and-smoke sequence) and collects every
+RC-required artifact — the npm tarball, the conformance-kit archive, and
+(once Phase 6 Tasks 1/2 land) the certification manifest and release
+attestation — into `dist/rc-rehearsal/`, printing their versions, source
+commit, and hashes so a human can confirm they agree before cutting a real
+RC. Exits non-zero on any failure; never runs `npm publish`, `npm version`,
+or creates a tag.
+
+Usage:
+    python scripts/rehearse-rc.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / "dist" / "rc-rehearsal"
+
+# Stage B (Phase 6 Tasks 1/2) drop their generators here once they land;
+# Stage A runs standalone and reports them as pending until then.
+MANIFEST_SCRIPT = ROOT / "scripts" / "build-certification-manifest.py"
+ATTESTATION_SCRIPT = ROOT / "scripts" / "build-certification-attestation.py"
+
+
+class RehearsalError(RuntimeError):
+    pass
+
+
+def run(cmd: list, **kwargs) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        cmd, cwd=ROOT, capture_output=True, text=True, **kwargs
+    )
+    if result.returncode != 0:
+        raise RehearsalError(
+            f"command failed ({' '.join(cmd)}):\n{result.stderr}"
+        )
+    return result
+
+
+def sha256_of(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def source_commit() -> str:
+    return run(["git", "rev-parse", "HEAD"]).stdout.strip()
+
+
+def package_version() -> str:
+    return json.loads((ROOT / "package.json").read_text())["version"]
+
+
+def step_build_catalog() -> None:
+    print("== build catalog (python build.py) ==")
+    run([sys.executable, "build.py"])
+    print("ok")
+
+
+def step_verify_package_boundary() -> None:
+    print("== package boundary check (npm pack --dry-run --json | verify_package_contents.py) ==")
+    pack = run(["npm", "pack", "--dry-run", "--json"])
+    verify = subprocess.run(
+        [sys.executable, "scripts/verify_package_contents.py"],
+        cwd=ROOT,
+        input=pack.stdout,
+        capture_output=True,
+        text=True,
+    )
+    if verify.returncode != 0:
+        raise RehearsalError(f"package boundary check failed:\n{verify.stderr}")
+    print(verify.stdout.strip())
+
+
+def step_install_and_smoke() -> None:
+    print("== install + smoke sequence (existing clean-consumer tests) ==")
+    run(
+        [
+            sys.executable,
+            "-m",
+            "unittest",
+            "tests.test_package.PackageMetadataTests."
+            "test_real_tarball_resolves_from_a_clean_consumer",
+            "tests.test_package.PackageMetadataTests."
+            "test_sass_facade_compiles_from_a_clean_consumer",
+            "-v",
+        ]
+    )
+    print("ok")
+
+
+def step_collect_tarball() -> Path:
+    print("== collect a persistent tarball for inspection ==")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    pack = run(
+        [
+            "npm",
+            "pack",
+            "--json",
+            "--pack-destination",
+            str(OUT_DIR),
+        ]
+    )
+    payload = json.loads(pack.stdout)
+    tarball = OUT_DIR / payload[0]["filename"]
+    if not tarball.is_file():
+        raise RehearsalError(f"expected tarball not found: {tarball}")
+    print(f"{tarball} ({sha256_of(tarball)})")
+    return tarball
+
+
+def step_conformance_kit() -> Path:
+    print("== conformance kit archive (Phase 5) ==")
+    contract = json.loads(
+        (ROOT / "conformance/contract/conformance-contract.json").read_text()
+    )
+    kit_version = contract["schemaVersion"]
+    kit_out_dir = OUT_DIR / "conformance-kit"
+    run(
+        [
+            sys.executable,
+            "scripts/package-conformance-kit.py",
+            "--version",
+            kit_version,
+            "--out-dir",
+            str(kit_out_dir),
+        ]
+    )
+    archive = kit_out_dir / f"moo-ui-conformance-kit-{kit_version}.tar.gz"
+    if not archive.is_file():
+        raise RehearsalError(f"expected conformance-kit archive not found: {archive}")
+    print(f"{archive} ({sha256_of(archive)})")
+    return archive
+
+
+def step_manifest_and_attestation() -> list:
+    print("== certification manifest + attestation (Phase 6 Tasks 1/2) ==")
+    collected = []
+    for label, script in (
+        ("manifest", MANIFEST_SCRIPT),
+        ("attestation", ATTESTATION_SCRIPT),
+    ):
+        if not script.is_file():
+            print(f"{label}: pending — {script.name} does not exist yet")
+            continue
+        print(f"{label}: {script.name} exists, but Stage B wiring is not implemented yet")
+        collected.append(script)
+    return collected
+
+
+def main() -> int:
+    try:
+        step_build_catalog()
+        step_verify_package_boundary()
+        step_install_and_smoke()
+        tarball = step_collect_tarball()
+        kit_archive = step_conformance_kit()
+        pending = step_manifest_and_attestation()
+    except RehearsalError as error:
+        print(f"\nREHEARSAL FAILED: {error}", file=sys.stderr)
+        return 1
+
+    print("\n== summary ==")
+    print(f"package version: {package_version()}")
+    print(f"source commit:   {source_commit()}")
+    print(f"tarball:         {tarball} ({sha256_of(tarball)})")
+    print(f"conformance kit: {kit_archive} ({sha256_of(kit_archive)})")
+    if pending:
+        print(
+            "Stage B (manifest/attestation) not wired in yet — "
+            f"{len(pending)} generator script(s) present but not integrated."
+        )
+    else:
+        print(
+            "Stage B (manifest/attestation) generators not found — "
+            "waiting on Phase 6 Tasks 1/2."
+        )
+    print("\nREHEARSAL OK (no publish, no tag)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rehearse-rc.py
+++ b/scripts/rehearse-rc.py
@@ -101,6 +101,7 @@ def step_install_and_smoke() -> None:
 
 def step_collect_tarball() -> Path:
     print("== collect a persistent tarball for inspection ==")
+    shutil.rmtree(OUT_DIR, ignore_errors=True)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     pack = run(
         [
@@ -201,6 +202,15 @@ def step_attestation(tarball: Path, commit: str) -> Path | None:
             platform.platform(),
             "--automated-evidence",
             evidence_uri(),
+            "--limitation",
+            "browsers",
+            (
+                "The 'rehearsal' browser entry above did not drive any real "
+                "browser; it exists only to satisfy the attestation "
+                "schema's browsers[] minItems requirement for this local "
+                "rehearsal run. Real cross-browser evidence comes from the "
+                "nightly certification matrix, not this script."
+            ),
         ]
     )
     print(f"{attestation_path} ({sha256_of(attestation_path)})")

--- a/scss/settings/_components.scss
+++ b/scss/settings/_components.scss
@@ -43,6 +43,7 @@ $kbd-bg: var(--bs-secondary-bg-subtle) !default;
 $moo-code-padding-y: 0.125rem !default;
 $moo-code-padding-x: 0.375rem !default;
 $moo-code-color: var(--bs-secondary-color) !default;
+
 // Matches the shadcn reference inline-code background (#f5f5f5) far more
 // closely than any --bs-*-bg step; --moo-muted-surface (#f4f4f5) is
 // effectively the same value.

--- a/scss/settings/_components.scss
+++ b/scss/settings/_components.scss
@@ -42,7 +42,16 @@ $kbd-bg: var(--bs-secondary-bg-subtle) !default;
 // <kbd>'s own knobs.
 $moo-code-padding-y: 0.125rem !default;
 $moo-code-padding-x: 0.375rem !default;
-$moo-code-color: var(--bs-secondary-color) !default;
+// var(--bs-secondary-color) on this chip's own var(--moo-muted-surface)
+// background measures 4.40:1 in light mode, under the 4.5:1 WCAG AA
+// minimum for normal text — the same defect the Tabs trigger and Kbd
+// contrast fixes hit against this exact background/alias combination
+// (Moo UI's theme sets --bs-secondary-color: var(--moo-muted-foreground),
+// so it resolves to the same failing color; see scss/components/_tabs.scss).
+// var(--bs-secondary-text-emphasis) is the untouched Bootstrap token built
+// for accessible text on a tinted surface, and measures 5.55:1 light /
+// 14.03:1 dark against this same background.
+$moo-code-color: var(--bs-secondary-text-emphasis) !default;
 
 // Matches the shadcn reference inline-code background (#f5f5f5) far more
 // closely than any --bs-*-bg step; --moo-muted-surface (#f4f4f5) is

--- a/scss/settings/_components.scss
+++ b/scss/settings/_components.scss
@@ -43,7 +43,10 @@ $kbd-bg: var(--bs-secondary-bg-subtle) !default;
 $moo-code-padding-y: 0.125rem !default;
 $moo-code-padding-x: 0.375rem !default;
 $moo-code-color: var(--bs-secondary-color) !default;
-$moo-code-bg: var(--bs-secondary-bg) !default;
+// Matches the shadcn reference inline-code background (#f5f5f5, measured
+// directly from ui.shadcn.com) far more closely than any --bs-*-bg step;
+// --moo-muted-surface (#f4f4f5) is effectively the same value.
+$moo-code-bg: var(--moo-muted-surface) !default;
 // The reference breadcrumb uses a chevron divider; Bootstrap's own default is "/".
 $breadcrumb-divider: quote(">") !default;
 $breadcrumb-divider-flipped: quote("<") !default;

--- a/scss/settings/_components.scss
+++ b/scss/settings/_components.scss
@@ -43,9 +43,9 @@ $kbd-bg: var(--bs-secondary-bg-subtle) !default;
 $moo-code-padding-y: 0.125rem !default;
 $moo-code-padding-x: 0.375rem !default;
 $moo-code-color: var(--bs-secondary-color) !default;
-// Matches the shadcn reference inline-code background (#f5f5f5, measured
-// directly from ui.shadcn.com) far more closely than any --bs-*-bg step;
-// --moo-muted-surface (#f4f4f5) is effectively the same value.
+// Matches the shadcn reference inline-code background (#f5f5f5) far more
+// closely than any --bs-*-bg step; --moo-muted-surface (#f4f4f5) is
+// effectively the same value.
 $moo-code-bg: var(--moo-muted-surface) !default;
 // The reference breadcrumb uses a chevron divider; Bootstrap's own default is "/".
 $breadcrumb-divider: quote(">") !default;

--- a/site/scss/catalog/_code.scss
+++ b/site/scss/catalog/_code.scss
@@ -89,10 +89,14 @@
 
 // references/bootstrap/5.3.3/scss/_variables.scss:1739-1740 gives <code>
 // only $code-color/$code-font-size, no background/padding/radius token
-// (see $moo-code-* in _primary_variables.scss for the gap citation and
+// (see $moo-code-* in settings/_components.scss for the gap citation and
 // why this doesn't just reuse <kbd>'s own knobs). Scoped to prose so it
 // never touches the syntax-highlighted code panel's own <code> rule above.
-.moo-doc-main :where(p, li) code {
+// Uses .moo-catalog__content (present on every catalog page) rather than
+// .moo-doc-main (only rendered for component/utility/block pages) so
+// Sections-type pages get the same treatment instead of falling back to
+// Bootstrap's unstyled reboot <code>.
+.moo-catalog__content :where(p, li) code {
   padding: $moo-code-padding-y $moo-code-padding-x;
   color: $moo-code-color;
   background: $moo-code-bg;

--- a/src/certification/evidence-inventory.json
+++ b/src/certification/evidence-inventory.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "0.1",
   "status": "baseline",
-  "description": "Pre-certification evidence inventory for the 40 components ready in Moo UI Core 0.4.0. Profile status is conservative: static source assertions count as existing contract evidence, while browser, accessibility-engine, visual, lifecycle, and host-conformance evidence remains missing until the certification harness proves it.",
+  "description": "Pre-certification evidence inventory for the 42 components ready in Moo UI Core 0.4.0. Profile status is conservative: static source assertions count as existing contract evidence, while browser, accessibility-engine, visual, lifecycle, and host-conformance evidence remains missing until the certification harness proves it.",
   "genericHostConformanceKit": {
     "status": "built-and-self-proven",
     "contractVersion": "1.0",

--- a/src/certification/manual-acceptance/2026-08-06-rc1-manual-acceptance.md
+++ b/src/certification/manual-acceptance/2026-08-06-rc1-manual-acceptance.md
@@ -2,34 +2,62 @@
 
 Generated: 2026-08-06
 Status: Draft — pending human execution against the final 1.0.0-rc.1 tarball
-Scope: Release-candidate manual acceptance for all 42 Core components: real-device passes, manual keyboard/focus checks, and screen-reader smoke, per the certification plan's "Release candidate" cadence (exact tarball, local real devices, manual keyboard/focus/screen-reader checklist). Automated browser and Bootstrap-lane coverage is produced by the nightly matrix and is not repeated here.
+Scope: Release-candidate manual acceptance for all 42 Core components, at
+each component's own tiered depth (see Component Matrix below — manual
+keyboard/focus checks and screen-reader smoke apply where a component's
+tier requires them, per the depth legend, not uniformly across all 42),
+per the certification plan's "Release candidate" cadence (exact tarball,
+local real devices, tier-scoped manual checklist). Automated browser and
+Bootstrap-lane coverage is produced by the nightly matrix and is not
+repeated here.
 
 ## How to prepare
 
-1. Build and install the exact RC tarball in a clean consumer project (Task 6
-   rehearsal path), or serve the catalog from this checkout:
-   `python3 dev.py --host 0.0.0.0` (catalog at `http://<host>:4173/`).
-2. Record the exact browser and operating-system versions for every device —
-   the release attestation's `realDevices` and `manualReviews` sections quote
-   these verbatim (SUPPORT.md Browser Policy).
+1. Build and install the exact RC tarball in a clean consumer project (Task
+   6 rehearsal path). This is the only source of acceptance evidence.
+   Serving the catalog from this dev checkout (`python3 dev.py --host
+   0.0.0.0`, catalog at `http://<host>:4173/`) tests a mid-build tree, not
+   the exact RC package — use it for exploratory spot checks only, and
+   never record its results as acceptance or attestation evidence.
+2. Record the exact browser and operating-system versions, and the fields
+   below, for every device — the release attestation's `realDevices` and
+   `manualReviews` sections require these verbatim (see
+   `src/certification/attestation.schema.json`).
 3. Execute against the RC package outputs, not against a mid-build tree.
 
 ## Test Devices
 
 Fill in exact versions at execution time. The device set follows the
-SUPPORT.md Browser Policy surfaces that automated CI cannot cover.
+SUPPORT.md Browser Policy surfaces that automated CI cannot cover. Each
+device row below maps to one `realDevices` entry in the release
+attestation.
 
 - [ ] MacBook (macOS, current and previous stable Safari majors)
   - macOS version:
   - Safari version:
+  - Package sha256:
+  - Reviewer:
+  - Reviewed at (UTC, ISO-8601):
+  - Scenarios covered:
+  - Result (passed/failed):
   - Notes:
 - [ ] iPhone (iOS, current and previous stable iOS Safari majors)
   - iOS version:
   - Safari version:
+  - Package sha256:
+  - Reviewer:
+  - Reviewed at (UTC, ISO-8601):
+  - Scenarios covered:
+  - Result (passed/failed):
   - Notes:
 - [ ] Android device (current stable Android Chrome)
   - Android version:
   - Chrome version:
+  - Package sha256:
+  - Reviewer:
+  - Reviewed at (UTC, ISO-8601):
+  - Scenarios covered:
+  - Result (passed/failed):
   - Notes:
 
 ## URLs
@@ -38,6 +66,12 @@ SUPPORT.md Browser Policy surfaces that automated CI cannot cover.
 - Component page pattern: `/components/<slug>/`
 - Certification fixture pattern: `/tests/fixtures/certification/<slug>.html`
 - DataTable release-review preview: `/blocks/previews/datatable-release-review/`
+
+These four URLs are served by the catalog (dev checkout or a built
+`site-dist`), not by the installed `@wpmoo/ui` npm package itself — `build.py`
+does not currently copy `tests/fixtures/certification/` into `site-dist`, so
+until that's addressed, reach them via `python3 dev.py` per step 1 above for
+exploratory checks; they are not evidence sources for acceptance.
 
 ## Component Matrix
 
@@ -115,7 +149,9 @@ Depth scales with the evidence-inventory profile (see
 
 ## Global Checks
 
-Run once per device, across the catalog:
+Run once per device, across the catalog. This section backs one
+`manualReviews` entry per device (`scope`: "global checks — <device>",
+`reviewer`, `reviewedAt`, `result`):
 
 - [ ] Desktop Tab / Shift+Tab / Escape flow recorded
   - Notes:
@@ -142,10 +178,23 @@ Run once per device, across the catalog:
 - [ ] Known limitations written down
   - Notes:
 
+Reviewer:
+Reviewed at (UTC, ISO-8601):
+Result (passed/failed):
+
 ## Acceptance Result
 
 - [ ] Pass
 - [ ] Pass with documented limitations
 - [ ] Fail
+
+These map onto the release attestation's own `result`, `limitations`, and
+`waivers` fields: "Pass" sets the attestation's `result` to `"passed"`
+with no additional `limitations` beyond what the generator already
+records; "Pass with documented limitations" also sets `result: "passed"`
+but adds one `limitations` entry per gap found above; "Fail" sets
+`result: "failed"`, and certified status must not be claimed for this
+release. Any check above that could not be executed as designed needs a
+`waivers` entry naming the check and the reason it was skipped.
 
 Final notes:

--- a/src/certification/manual-acceptance/2026-08-06-rc1-manual-acceptance.md
+++ b/src/certification/manual-acceptance/2026-08-06-rc1-manual-acceptance.md
@@ -1,0 +1,151 @@
+# Moo UI 1.0.0-rc.1 Manual Acceptance
+
+Generated: 2026-08-06
+Status: Draft — pending human execution against the final 1.0.0-rc.1 tarball
+Scope: Release-candidate manual acceptance for all 42 Core components: real-device passes, manual keyboard/focus checks, and screen-reader smoke, per the certification plan's "Release candidate" cadence (exact tarball, local real devices, manual keyboard/focus/screen-reader checklist). Automated browser and Bootstrap-lane coverage is produced by the nightly matrix and is not repeated here.
+
+## How to prepare
+
+1. Build and install the exact RC tarball in a clean consumer project (Task 6
+   rehearsal path), or serve the catalog from this checkout:
+   `python3 dev.py --host 0.0.0.0` (catalog at `http://<host>:4173/`).
+2. Record the exact browser and operating-system versions for every device —
+   the release attestation's `realDevices` and `manualReviews` sections quote
+   these verbatim (SUPPORT.md Browser Policy).
+3. Execute against the RC package outputs, not against a mid-build tree.
+
+## Test Devices
+
+Fill in exact versions at execution time. The device set follows the
+SUPPORT.md Browser Policy surfaces that automated CI cannot cover.
+
+- [ ] MacBook (macOS, current and previous stable Safari majors)
+  - macOS version:
+  - Safari version:
+  - Notes:
+- [ ] iPhone (iOS, current and previous stable iOS Safari majors)
+  - iOS version:
+  - Safari version:
+  - Notes:
+- [ ] Android device (current stable Android Chrome)
+  - Android version:
+  - Chrome version:
+  - Notes:
+
+## URLs
+
+- Catalog home: `/`
+- Component page pattern: `/components/<slug>/`
+- Certification fixture pattern: `/tests/fixtures/certification/<slug>.html`
+- DataTable release-review preview: `/blocks/previews/datatable-release-review/`
+
+## Component Matrix
+
+Depth scales with the evidence-inventory profile (see
+`src/certification/evidence-inventory.json`):
+
+- **Visual**: catalog page in light + dark theme, LTR + RTL direction.
+- **Interactive**: Visual plus keyboard operation (Tab / Shift+Tab,
+  Enter/Space activation, arrow keys where documented), visible focus, focus
+  return after dismissal.
+- **Overlay**: Interactive plus trigger open/close, Escape, outside dismiss,
+  focus trap (dialog family) and focus return.
+- **Composite**: Overlay depth plus the documented end-to-end interaction and
+  a screen-reader smoke pass.
+
+### Tier 0 — static (Visual)
+
+- [ ] avatar
+- [ ] badge
+- [ ] card
+- [ ] kbd
+- [ ] progress
+- [ ] separator
+- [ ] skeleton
+- [ ] spinner
+- [ ] table
+- [ ] typography
+
+### Tier 0 — interactive (Interactive)
+
+- [ ] breadcrumb
+- [ ] button
+- [ ] button-group
+- [ ] checkbox
+- [ ] close-button
+- [ ] field
+- [ ] input
+- [ ] input-group
+- [ ] navigation
+- [ ] pagination
+- [ ] radio-group
+- [ ] select
+- [ ] switch
+- [ ] textarea
+
+### Tier 1 — Bootstrap data-API (Interactive)
+
+- [ ] accordion
+- [ ] alert
+- [ ] collapsible
+- [ ] dropdown-menu
+- [ ] tabs
+
+### Tier 1 — native state (Interactive)
+
+- [ ] toggle-group
+
+### Tier 2 — overlay (Overlay)
+
+- [ ] dialog
+- [ ] popover
+- [ ] sheet
+- [ ] toast
+- [ ] tooltip
+
+### Tier 3 — composites (Composite)
+
+- [ ] alert-dialog
+- [ ] combobox
+- [ ] context-menu
+- [ ] datatable
+- [ ] menubar
+- [ ] sidebar
+- [ ] form
+
+## Global Checks
+
+Run once per device, across the catalog:
+
+- [ ] Desktop Tab / Shift+Tab / Escape flow recorded
+  - Notes:
+- [ ] Focus is always visible and never trapped outside a dialog surface
+  - Notes:
+- [ ] Reduced-motion setting respected (no large non-essential animation)
+  - Notes:
+- [ ] 200% zoom: no clipped controls or lost content on key pages
+  - Notes:
+- [ ] Light + dark theme contrast spot check on each device
+  - Notes:
+- [ ] RTL direction spot check (at minimum: navigation, datatable, sidebar)
+  - Notes:
+- [ ] VoiceOver smoke on macOS Safari (dialog, combobox, datatable, toast)
+  - Notes:
+- [ ] VoiceOver smoke on iOS Safari (dialog, sidebar, datatable)
+  - Notes:
+- [ ] TalkBack smoke on Android Chrome (dialog, datatable)
+  - Notes:
+- [ ] Touch targets usable on phone/tablet (no hover-only interactions)
+  - Notes:
+- [ ] Console clean on every page visited (no errors, no deprecation noise)
+  - Notes:
+- [ ] Known limitations written down
+  - Notes:
+
+## Acceptance Result
+
+- [ ] Pass
+- [ ] Pass with documented limitations
+- [ ] Fail
+
+Final notes:

--- a/src/certification/rehearsals/2026-08-06-rc1-clean-install.md
+++ b/src/certification/rehearsals/2026-08-06-rc1-clean-install.md
@@ -1,0 +1,69 @@
+# Moo UI 1.0.0-rc.1 Clean Install Rehearsal
+
+Generated: 2026-08-06
+Status: Pass (rehearsal against the packed 0.9.0 tarball; repeat verbatim against the final RC tarball before tagging)
+Scope: Clean-room installation of `@wpmoo/ui` in an empty consumer project following the documented install path (catalog Installation page), plus the documented scoped gradual-adoption path.
+
+## Environment
+
+- Host: macOS 26.5.2
+- Node: v26.5.0, npm 11.17.0
+- Tarball: `wpmoo-ui-0.9.0.tgz` packed from the dev checkout (`npm pack`)
+  - sha256: `d61172626484771e195d85d610ebaca92a65a66b5ec00c6e0f61d3b9a27db091`
+- Registry substitution: `@wpmoo/ui` is not published yet, so the consumer
+  installed the local tarball in place of the registry package
+  (`npm install ../wpmoo-ui-0.9.0.tgz bootstrap` instead of
+  `npm install @wpmoo/ui bootstrap`). Everything downstream of the package
+  boundary is identical; the published RC must repeat this rehearsal.
+
+## Steps Executed
+
+1. Fresh empty directory; `npm init -y`.
+2. `npm install <tarball> bootstrap` — installed cleanly, 0 vulnerabilities.
+   - Bootstrap resolved to 5.3.8 (`^5.3.8`), the latest lane of the
+     `>=5.3.0 <5.4` peer range — matches bootstrap-compatibility.json.
+3. Verified every documented package export resolves from the consumer:
+   - `@wpmoo/ui/moo-ui.css`, `@wpmoo/ui/moo.css`
+   - `@wpmoo/ui/combobox.js`, `@wpmoo/ui/sidebar.js`,
+     `@wpmoo/ui/context-menu.js`, `@wpmoo/ui/datatable.js`
+   - `@wpmoo/ui/certification.json`
+4. Full-build consumer page (`moo-ui.css` + Bootstrap bundle + optional ESM
+   import), served from the consumer directory, loaded in headless Chromium:
+   - `btn btn-primary` receives Moo UI styling (background rgb(24, 24, 27)).
+   - Bootstrap dropdown opens via its data API (`aria-expanded` → `true`).
+   - `Combobox.getOrCreateInstance` and `DataTable.getOrCreateInstance` are
+     functions after a side-effect-free ESM import.
+   - Console and page errors: none.
+5. Scoped-adoption consumer page (Bootstrap CSS first, then `moo.css`,
+   migrated markup inside `.moo-ui`):
+   - Inside `.moo-ui`: button styled by the Moo layer.
+   - Outside `.moo-ui`: button keeps stock Bootstrap styling
+     (rgb(108, 117, 125)) — the boundary is respected, matching the
+     Installation page's "Scoped Gradual Adoption" guidance.
+
+## Migration Path Cross-Check
+
+SUPPORT.md's migration guidance is the SemVer policy (patch releases never
+intentionally break public contracts; breaking changes only in a minor with
+an explicit migration note). `1.0.0-rc.1` has no predecessor 1.x line, so no
+1.x-to-1.x migration note applies; the 0.x → 1.0 surface is frozen by
+`src/certification/api-freeze-0.9.0.json` (Task 7 confirmed no drift since).
+The documented gradual path from a plain Bootstrap 5.3 app is the scoped
+adoption path verified above.
+
+## Doc Drift Found
+
+None. The Installation page's npm command, stylesheet paths, Bootstrap
+bundle usage, optional-ESM module names, and the `getOrCreateInstance` /
+`dispose` lifecycle all match the installed package. CDN URL shapes
+(unpkg/jsdelivr with `/dist/assets/css/...`) match the package layout but
+cannot be verified until the package is published — re-check at the real RC.
+
+## Result
+
+- [X] Pass
+- [ ] Pass with documented limitations
+- [ ] Fail
+
+Final notes: Re-run against the actual 1.0.0-rc.1 tarball (same steps) and
+record its sha256 in the release attestation evidence.

--- a/src/certification/rehearsals/2026-08-06-rc1-clean-install.md
+++ b/src/certification/rehearsals/2026-08-06-rc1-clean-install.md
@@ -1,7 +1,7 @@
 # Moo UI 1.0.0-rc.1 Clean Install Rehearsal
 
 Generated: 2026-08-06
-Status: Pass (rehearsal against the packed 0.9.0 tarball; repeat verbatim against the final RC tarball before tagging)
+Status: Pass with documented limitations (rehearsal against the packed 0.9.0 tarball; repeat verbatim against the final RC tarball before tagging)
 Scope: Clean-room installation of `@wpmoo/ui` in an empty consumer project following the documented install path (catalog Installation page), plus the documented scoped gradual-adoption path.
 
 ## Environment
@@ -10,6 +10,10 @@ Scope: Clean-room installation of `@wpmoo/ui` in an empty consumer project follo
 - Node: v26.5.0, npm 11.17.0
 - Tarball: `wpmoo-ui-0.9.0.tgz` packed from the dev checkout (`npm pack`)
   - sha256: `d61172626484771e195d85d610ebaca92a65a66b5ec00c6e0f61d3b9a27db091`
+  - Source commit: not recorded — this rehearsal predates the
+    `--source-commit` provenance binding added to the certification
+    generators later in Phase 6. The final RC re-run must capture the
+    checkout's exact commit alongside the tarball sha256.
 - Registry substitution: `@wpmoo/ui` is not published yet, so the consumer
   installed the local tarball in place of the registry package
   (`npm install ../wpmoo-ui-0.9.0.tgz bootstrap` instead of
@@ -61,9 +65,12 @@ cannot be verified until the package is published — re-check at the real RC.
 
 ## Result
 
-- [X] Pass
-- [ ] Pass with documented limitations
+- [ ] Pass
+- [X] Pass with documented limitations
 - [ ] Fail
 
 Final notes: Re-run against the actual 1.0.0-rc.1 tarball (same steps) and
-record its sha256 in the release attestation evidence.
+record its sha256 and source commit in the release attestation evidence. The
+sole limitation on this rehearsal is the missing source commit above; every
+functional check (install, exports, styling boundary, migration path) passed
+cleanly.

--- a/src/certification/rehearsals/2026-08-06-rc1-clean-install.md
+++ b/src/certification/rehearsals/2026-08-06-rc1-clean-install.md
@@ -69,8 +69,12 @@ cannot be verified until the package is published — re-check at the real RC.
 - [X] Pass with documented limitations
 - [ ] Fail
 
-Final notes: Re-run against the actual 1.0.0-rc.1 tarball (same steps) and
-record its sha256 and source commit in the release attestation evidence. The
-sole limitation on this rehearsal is the missing source commit above; every
-functional check (install, exports, styling boundary, migration path) passed
-cleanly.
+Final notes: every functional check (install, exports, styling boundary,
+migration path) passed cleanly. Documented limitations, all closed by
+re-running against the actual, published 1.0.0-rc.1 tarball: (1) this
+rehearsal used the packed 0.9.0 tarball, not the final RC tarball; (2) its
+source commit was not recorded (see Environment); (3) the registry
+substitution means the real `npm install @wpmoo/ui bootstrap` path was not
+exercised; (4) CDN URL shapes could not be verified against a published
+package. Re-run against the actual 1.0.0-rc.1 tarball (same steps) and
+record its sha256 and source commit in the release attestation evidence.

--- a/tests/helpers/browser_harness.py
+++ b/tests/helpers/browser_harness.py
@@ -119,6 +119,11 @@ class BrowserEvidence:
 
 
 def launch_certification_browser(playwright: Playwright) -> Browser:
+    engine = os.environ.get("MOO_UI_BROWSER_ENGINE", "chromium").lower()
+    if engine not in {"chromium", "firefox", "webkit"}:
+        raise AssertionError(f"Unsupported browser engine: {engine!r}")
+    if engine != "chromium":
+        return getattr(playwright, engine).launch()
     configured_channel = os.environ.get("MOO_UI_BROWSER_CHANNEL")
     if configured_channel:
         return playwright.chromium.launch(channel=configured_channel)
@@ -128,14 +133,20 @@ def launch_certification_browser(playwright: Playwright) -> Browser:
 
 
 def new_case_context(browser: Browser, case: BrowserCase) -> BrowserContext:
-    return browser.new_context(
-        viewport=case.viewport,
-        color_scheme=case.color_scheme,
-        is_mobile=case.is_mobile,
-        has_touch=case.has_touch,
-        reduced_motion="reduce",
-        locale="en-US",
-    )
+    options: dict[str, object] = {
+        "viewport": case.viewport,
+        "color_scheme": case.color_scheme,
+        "reduced_motion": "reduce",
+        "locale": "en-US",
+    }
+    # Firefox rejects the mobile/touch emulation options ("options.isMobile
+    # is not supported in Firefox"); Chromium and WebKit accept them. On
+    # Firefox the mobile case still runs with its viewport, theme, and
+    # direction, just without isMobile/hasTouch emulation.
+    if browser.browser_type.name != "firefox":
+        options["is_mobile"] = case.is_mobile
+        options["has_touch"] = case.has_touch
+    return browser.new_context(**options)
 
 
 def prepare_page(

--- a/tests/test_browser_harness.py
+++ b/tests/test_browser_harness.py
@@ -1,0 +1,53 @@
+"""Engine-selection tests for the certification browser harness.
+
+The nightly matrix runs the browser suite across Chromium, Firefox, and
+WebKit via ``MOO_UI_BROWSER_ENGINE``. These tests lock the selection logic
+without launching a browser, so they stay fast and run even in the
+Chromium-only PR gate: an unknown engine must fail loudly rather than fall
+back to a silently different engine.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from unittest import mock
+
+from tests.helpers.browser_harness import launch_certification_browser
+
+
+class BrowserHarnessEngineSelectionTests(unittest.TestCase):
+    def test_unsupported_engine_fails_loudly(self) -> None:
+        with mock.patch.dict(os.environ, {"MOO_UI_BROWSER_ENGINE": "netscape"}):
+            with self.assertRaises(AssertionError) as context:
+                launch_certification_browser(object())
+        self.assertIn("Unsupported browser engine", str(context.exception))
+
+    def test_default_engine_is_chromium(self) -> None:
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key != "MOO_UI_BROWSER_ENGINE"
+        }
+        with mock.patch.dict(os.environ, environment, clear=True):
+            # The engine check passes for the default and proceeds toward a
+            # Chromium launch; stub the launcher so no browser actually starts.
+            playwright = mock.Mock()
+            launch_certification_browser(playwright)
+        playwright.chromium.launch.assert_called_once()
+        playwright.firefox.launch.assert_not_called()
+        playwright.webkit.launch.assert_not_called()
+
+    def test_supported_non_chromium_engines_use_selected_launcher(self) -> None:
+        for engine in ("firefox", "webkit"):
+            with self.subTest(engine=engine):
+                playwright = mock.Mock()
+                with mock.patch.dict(os.environ, {"MOO_UI_BROWSER_ENGINE": engine}):
+                    launch_certification_browser(playwright)
+                getattr(playwright, engine).launch.assert_called_once_with()
+                for other_engine in {"chromium", "firefox", "webkit"} - {engine}:
+                    getattr(playwright, other_engine).launch.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_browser_harness.py
+++ b/tests/test_browser_harness.py
@@ -13,7 +13,11 @@ import os
 import unittest
 from unittest import mock
 
-from tests.helpers.browser_harness import launch_certification_browser
+from tests.helpers.browser_harness import (
+    BrowserCase,
+    launch_certification_browser,
+    new_case_context,
+)
 
 
 class BrowserHarnessEngineSelectionTests(unittest.TestCase):
@@ -47,6 +51,43 @@ class BrowserHarnessEngineSelectionTests(unittest.TestCase):
                 getattr(playwright, engine).launch.assert_called_once_with()
                 for other_engine in {"chromium", "firefox", "webkit"} - {engine}:
                     getattr(playwright, other_engine).launch.assert_not_called()
+
+
+class NewCaseContextEngineOptionsTests(unittest.TestCase):
+    """Lock the is_mobile/has_touch guard added for Firefox: it rejects
+    those context options ("options.isMobile is not supported in Firefox"),
+    so new_case_context must omit them only on that engine."""
+
+    MOBILE_CASE = BrowserCase(
+        name="mobile-dark-rtl",
+        viewport={"width": 390, "height": 844},
+        color_scheme="dark",
+        direction="rtl",
+        is_mobile=True,
+        has_touch=True,
+    )
+
+    def _browser_named(self, engine: str) -> mock.Mock:
+        browser = mock.Mock()
+        browser.browser_type.name = engine
+        return browser
+
+    def test_firefox_omits_mobile_and_touch_options(self) -> None:
+        browser = self._browser_named("firefox")
+        new_case_context(browser, self.MOBILE_CASE)
+        _, kwargs = browser.new_context.call_args
+        self.assertNotIn("is_mobile", kwargs)
+        self.assertNotIn("has_touch", kwargs)
+        self.assertEqual(kwargs["viewport"], self.MOBILE_CASE.viewport)
+
+    def test_chromium_and_webkit_include_mobile_and_touch_options(self) -> None:
+        for engine in ("chromium", "webkit"):
+            with self.subTest(engine=engine):
+                browser = self._browser_named(engine)
+                new_case_context(browser, self.MOBILE_CASE)
+                _, kwargs = browser.new_context.call_args
+                self.assertEqual(kwargs["is_mobile"], True)
+                self.assertEqual(kwargs["has_touch"], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_certification_browser.py
+++ b/tests/test_certification_browser.py
@@ -343,14 +343,18 @@ class CertificationBrowserHarnessTests(unittest.TestCase):
                 context.close()
 
     def test_sidebar_mobile_offcanvas_keeps_bootstrap_transform_transition(self) -> None:
-        context = self.browser.new_context(
-            viewport={"width": 390, "height": 844},
-            color_scheme="light",
-            is_mobile=True,
-            has_touch=True,
-            reduced_motion="no-preference",
-            locale="en-US",
-        )
+        context_options: dict[str, object] = {
+            "viewport": {"width": 390, "height": 844},
+            "color_scheme": "light",
+            "reduced_motion": "no-preference",
+            "locale": "en-US",
+        }
+        # Firefox rejects the mobile/touch emulation options; the offcanvas
+        # transition under audit does not depend on them.
+        if self.browser.browser_type.name != "firefox":
+            context_options["is_mobile"] = True
+            context_options["has_touch"] = True
+        context = self.browser.new_context(**context_options)
         page = context.new_page()
         evidence = BrowserEvidence(page)
         response = page.goto(

--- a/tests/test_certification_contract.py
+++ b/tests/test_certification_contract.py
@@ -9,6 +9,8 @@ from collections import Counter
 from pathlib import Path
 from urllib.parse import urlparse
 
+from jsonschema import Draft202012Validator
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CERTIFICATION_ROOT = ROOT / "src/certification"
@@ -316,7 +318,14 @@ class CertificationContractTests(unittest.TestCase):
                 self.assertEqual(lane["build"], "passed")
                 self.assertEqual(lane["browserCertification"], "passed")
 
-    def test_preview_attestation_is_built_from_the_real_tarball(self) -> None:
+    def test_core_attestation_is_built_from_the_real_tarball(self) -> None:
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
             pack_result = subprocess.run(
@@ -345,7 +354,7 @@ class CertificationContractTests(unittest.TestCase):
                     "--output",
                     str(output),
                     "--source-commit",
-                    "a" * 40,
+                    head_commit,
                     "--browser-name",
                     "Chromium",
                     "--browser-version",
@@ -365,10 +374,15 @@ class CertificationContractTests(unittest.TestCase):
             self.assertEqual(build_result.returncode, 0, build_result.stderr)
             attestation = json.loads(output.read_text(encoding="utf-8"))
 
+            schema = self._read_json("src/certification/attestation.schema.json")
+            validator = Draft202012Validator(schema)
+            errors = list(validator.iter_errors(attestation))
+            self.assertEqual(errors, [], [error.message for error in errors])
+
             self.assertEqual(attestation["status"], "preview")
-            self.assertEqual(attestation["scope"], "phase-0-pilot")
+            self.assertEqual(attestation["scope"], "core")
             self.assertEqual(attestation["result"], "passed")
-            self.assertEqual(attestation["sourceCommit"], "a" * 40)
+            self.assertEqual(attestation["sourceCommit"], head_commit)
             self.assertEqual(attestation["createdAt"], "2026-07-27T00:00:00Z")
             self.assertEqual(
                 attestation["package"]["version"],
@@ -379,14 +393,69 @@ class CertificationContractTests(unittest.TestCase):
                 attestation["package"]["manifestSha256"],
                 r"^[0-9a-f]{64}$",
             )
+            inventory = self._read_json(
+                "src/certification/evidence-inventory.json"
+            )
             self.assertEqual(
                 [component["slug"] for component in attestation["components"]],
-                ["badge", "accordion", "dialog", "combobox", "sidebar"],
+                [component["slug"] for component in inventory["components"]],
             )
+            self.assertEqual(len(attestation["components"]), 42)
+            for component in attestation["components"]:
+                self.assertGreaterEqual(len(component["checks"]), 1)
             self.assertEqual(attestation["manualReviews"], [])
             self.assertEqual(attestation["realDevices"], [])
             self.assertEqual(attestation["waivers"], [])
-            self.assertIn("not a complete release certification", attestation["limitations"][0]["description"])
+            self.assertIn(
+                "Core-only", attestation["limitations"][0]["description"]
+            )
+
+    def test_attestation_rejects_a_source_commit_not_at_the_checkout(self) -> None:
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        foreign_commit = "a" * 40 if head_commit != "a" * 40 else "b" * 40
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            pack_result = subprocess.run(
+                ["npm", "pack", "--json", "--pack-destination", str(temporary_root)],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(pack_result.returncode, 0, pack_result.stderr)
+            tarball = temporary_root / json.loads(pack_result.stdout)[0]["filename"]
+            build_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts/build-certification-attestation.py"),
+                    "--package",
+                    str(tarball),
+                    "--output",
+                    str(temporary_root / "attestation.json"),
+                    "--source-commit",
+                    foreign_commit,
+                    "--browser-name",
+                    "Chromium",
+                    "--browser-version",
+                    "test",
+                    "--operating-system",
+                    "test",
+                    "--automated-evidence",
+                    "https://github.com/wpmoo-org/ui/actions/runs/example",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(build_result.returncode, 0)
+        self.assertIn("must match the checkout HEAD", build_result.stderr)
 
     def test_core_certification_sources_do_not_name_commercial_bridges(self) -> None:
         public_sources = [

--- a/tests/test_certification_contract.py
+++ b/tests/test_certification_contract.py
@@ -421,15 +421,12 @@ class CertificationContractTests(unittest.TestCase):
         foreign_commit = "a" * 40 if head_commit != "a" * 40 else "b" * 40
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
-            pack_result = subprocess.run(
-                ["npm", "pack", "--json", "--pack-destination", str(temporary_root)],
-                cwd=ROOT,
-                check=False,
-                capture_output=True,
-                text=True,
-            )
-            self.assertEqual(pack_result.returncode, 0, pack_result.stderr)
-            tarball = temporary_root / json.loads(pack_result.stdout)[0]["filename"]
+            # build-certification-attestation.py rejects a commit mismatch
+            # before it ever opens --package as a tarball (it only checks
+            # that the path exists), so a real npm pack here would just be
+            # slower and less reliable for the same coverage.
+            tarball = temporary_root / "placeholder.tgz"
+            tarball.write_bytes(b"")
             build_result = subprocess.run(
                 [
                     sys.executable,

--- a/tests/test_certification_contract.py
+++ b/tests/test_certification_contract.py
@@ -406,9 +406,11 @@ class CertificationContractTests(unittest.TestCase):
             self.assertEqual(attestation["manualReviews"], [])
             self.assertEqual(attestation["realDevices"], [])
             self.assertEqual(attestation["waivers"], [])
-            self.assertIn(
-                "Core-only", attestation["limitations"][0]["description"]
-            )
+            surfaces = {
+                limitation["surface"] for limitation in attestation["limitations"]
+            }
+            self.assertIn("release", surfaces)
+            self.assertIn("browsers", surfaces)
 
     def test_attestation_rejects_a_source_commit_not_at_the_checkout(self) -> None:
         head_commit = subprocess.run(
@@ -453,6 +455,55 @@ class CertificationContractTests(unittest.TestCase):
             )
         self.assertNotEqual(build_result.returncode, 0)
         self.assertIn("must match the checkout HEAD", build_result.stderr)
+
+    def test_attestation_rejects_a_dirty_worktree(self) -> None:
+        # The commit-mismatch test above locks half of the provenance
+        # binding; this locks the other half. An untracked scratch file
+        # outside the gitignored dist/ is enough to dirty
+        # `git status --porcelain` without touching any tracked content
+        # that would need restoring.
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        scratch_marker = ROOT / "_test_dirty_worktree_marker.tmp"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            tarball = temporary_root / "placeholder.tgz"
+            tarball.write_bytes(b"")
+            try:
+                scratch_marker.write_text("dirtying the worktree for a test\n")
+                build_result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(ROOT / "scripts/build-certification-attestation.py"),
+                        "--package",
+                        str(tarball),
+                        "--output",
+                        str(temporary_root / "attestation.json"),
+                        "--source-commit",
+                        head_commit,
+                        "--browser-name",
+                        "Chromium",
+                        "--browser-version",
+                        "test",
+                        "--operating-system",
+                        "test",
+                        "--automated-evidence",
+                        "https://github.com/wpmoo-org/ui/actions/runs/example",
+                    ],
+                    cwd=ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+            finally:
+                scratch_marker.unlink(missing_ok=True)
+        self.assertNotEqual(build_result.returncode, 0)
+        self.assertIn("uncommitted changes", build_result.stderr)
 
     def test_core_certification_sources_do_not_name_commercial_bridges(self) -> None:
         public_sources = [

--- a/tests/test_certification_manifest.py
+++ b/tests/test_certification_manifest.py
@@ -173,6 +173,65 @@ class CertificationManifestTests(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("--source-commit", completed.stderr)
 
+    def test_certified_status_requires_an_attestation_file_not_just_a_uri(self) -> None:
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        with tempfile.TemporaryDirectory() as scratch:
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                head_commit,
+                "--attestation",
+                "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
+                package=str(self.tarball),
+                output=str(Path(scratch) / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("--attestation-file", completed.stderr)
+
+    def test_certified_status_rejects_a_mismatched_attestation(self) -> None:
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            forged = scratch_path / "attestation.json"
+            forged.write_text(
+                json.dumps(
+                    {
+                        "sourceCommit": "a" * 40,  # does not match head_commit
+                        "coreVersion": "0.0.0",
+                        "result": "passed",
+                        "package": {"sha256": "b" * 64},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                head_commit,
+                "--attestation",
+                "https://example.invalid/attestation.json",
+                "--attestation-file",
+                str(forged),
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("does not conform to attestation.schema.json", completed.stderr)
+
     def test_package_hash_mismatch_fails_loudly(self) -> None:
         with tempfile.TemporaryDirectory() as scratch:
             completed = run_generator(
@@ -183,6 +242,71 @@ class CertificationManifestTests(unittest.TestCase):
             )
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("package hash mismatch", completed.stderr)
+
+    def test_certified_status_accepts_a_real_matching_attestation(self) -> None:
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path = scratch_path / "attestation.json"
+            attestation_completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "build-certification-attestation.py"),
+                    "--package",
+                    str(self.tarball),
+                    "--output",
+                    str(attestation_path),
+                    "--source-commit",
+                    head_commit,
+                    "--browser-name",
+                    "test-harness",
+                    "--browser-version",
+                    "n/a",
+                    "--operating-system",
+                    "test",
+                    "--automated-evidence",
+                    "urn:test:manifest-certified-status",
+                ],
+                cwd=ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=GENERATOR_TIMEOUT_SECONDS,
+            )
+            self.assertEqual(
+                attestation_completed.returncode, 0, attestation_completed.stderr
+            )
+
+            output_path = scratch_path / "out.json"
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                head_commit,
+                "--attestation",
+                "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                package=str(self.tarball),
+                output=str(output_path),
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            manifest = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["status"], "certified")
+        self.assertEqual(manifest["sourceCommit"], head_commit)
+        errors = list(
+            Draft202012Validator(
+                json.loads(SCHEMA.read_text(encoding="utf-8"))
+            ).iter_errors(manifest)
+        )
+        self.assertEqual(errors, [], [error.message for error in errors])
 
 
 if __name__ == "__main__":

--- a/tests/test_certification_manifest.py
+++ b/tests/test_certification_manifest.py
@@ -581,6 +581,11 @@ class CertificationManifestTests(unittest.TestCase):
 
         self.assertEqual(manifest["status"], "certified")
         self.assertEqual(manifest["sourceCommit"], self.head_commit)
+        self.assertEqual(
+            manifest["attestation"],
+            "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
+        )
+        self.assertTrue(manifest["browserPolicy"]["exactEvidenceInAttestation"])
         errors = list(
             Draft202012Validator(
                 json.loads(SCHEMA.read_text(encoding="utf-8"))

--- a/tests/test_certification_manifest.py
+++ b/tests/test_certification_manifest.py
@@ -10,6 +10,7 @@ under-reporting manifest would be worse than no manifest.
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 import subprocess
 import sys
@@ -22,10 +23,20 @@ from jsonschema import Draft202012Validator
 from tests.helpers import ROOT
 
 SCRIPT = ROOT / "scripts" / "build-certification-manifest.py"
+ATTESTATION_SCRIPT = ROOT / "scripts" / "build-certification-attestation.py"
 SCHEMA = ROOT / "src" / "certification" / "manifest.schema.json"
 INVENTORY = ROOT / "src" / "certification" / "evidence-inventory.json"
 PACK_TIMEOUT_SECONDS = 180
 GENERATOR_TIMEOUT_SECONDS = 120
+
+
+def load_attestation_generator():
+    spec = importlib.util.spec_from_file_location(
+        "build_certification_attestation", ATTESTATION_SCRIPT
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def pack_tarball(destination: Path) -> Path:
@@ -86,6 +97,11 @@ class CertificationManifestTests(unittest.TestCase):
         cls.core_version = json.loads(
             (ROOT / "package.json").read_text(encoding="utf-8")
         )["version"]
+        # The same records a real attestation would carry for every
+        # evidence-inventory component - reused so the certified-status
+        # fixtures below are internally consistent by construction rather
+        # than hand-typed and liable to drift from the real generator.
+        cls.attested_components = load_attestation_generator().certified_components()
 
     @staticmethod
     def _head_commit() -> str:
@@ -132,7 +148,7 @@ class CertificationManifestTests(unittest.TestCase):
                     "result": "passed",
                 }
             ],
-            "components": [],
+            "components": self.attested_components,
             "automatedRuns": [
                 {
                     "name": "test-harness",
@@ -339,6 +355,130 @@ class CertificationManifestTests(unittest.TestCase):
             )
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("sourceCommit does not match", completed.stderr)
+
+    def test_certified_status_rejects_a_valid_attestation_for_another_core_version(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path, attestation_sha256 = self._write_certified_attestation(
+                scratch_path, coreVersion="0.0.0-not-this-release"
+            )
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                self.head_commit,
+                "--attestation",
+                "https://example.invalid/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                "--attestation-sha256",
+                attestation_sha256,
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("coreVersion does not match", completed.stderr)
+
+    def test_certified_status_rejects_a_valid_attestation_for_another_package(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path, attestation_sha256 = self._write_certified_attestation(
+                scratch_path,
+                package={
+                    "name": "@wpmoo/ui",
+                    "version": self.core_version,
+                    "filename": self.tarball.name,
+                    "sha256": "0" * 64,
+                    "manifestSha256": "0" * 64,
+                },
+            )
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                self.head_commit,
+                "--attestation",
+                "https://example.invalid/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                "--attestation-sha256",
+                attestation_sha256,
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("package hash does not match", completed.stderr)
+
+    def test_certified_status_rejects_an_attestation_missing_a_certified_component(
+        self,
+    ) -> None:
+        # Every component the manifest certifies must actually appear in
+        # the attestation it cites - otherwise a manifest could claim a
+        # component is certified while its own attestation never mentions
+        # it at all.
+        missing_slug = self.attested_components[0]["slug"]
+        components_missing_one = [
+            component
+            for component in self.attested_components
+            if component["slug"] != missing_slug
+        ]
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path, attestation_sha256 = self._write_certified_attestation(
+                scratch_path, components=components_missing_one
+            )
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                self.head_commit,
+                "--attestation",
+                "https://example.invalid/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                "--attestation-sha256",
+                attestation_sha256,
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn(missing_slug, completed.stderr)
+        self.assertIn("no matching entry", completed.stderr)
+
+    def test_certified_status_rejects_an_attestation_with_a_failed_component(
+        self,
+    ) -> None:
+        # A component present in the attestation but not passed must also
+        # block certified status, not just an absent one.
+        components_with_a_failure = [
+            dict(component, result="failed") if index == 0 else component
+            for index, component in enumerate(self.attested_components)
+        ]
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path, attestation_sha256 = self._write_certified_attestation(
+                scratch_path, components=components_with_a_failure
+            )
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                self.head_commit,
+                "--attestation",
+                "https://example.invalid/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                "--attestation-sha256",
+                attestation_sha256,
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("not 'passed'", completed.stderr)
 
     def test_package_hash_mismatch_fails_loudly(self) -> None:
         with tempfile.TemporaryDirectory() as scratch:

--- a/tests/test_certification_manifest.py
+++ b/tests/test_certification_manifest.py
@@ -1,0 +1,189 @@
+"""Schema and fault-injection tests for the certification manifest generator.
+
+The manifest is the Core-only certification summary shipped with a release,
+so the generator must produce documents that validate against
+``src/certification/manifest.schema.json`` and must fail loudly whenever
+the evidence it certifies cannot actually be produced — a silently
+under-reporting manifest would be worse than no manifest.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from tests.helpers import ROOT
+
+SCRIPT = ROOT / "scripts" / "build-certification-manifest.py"
+SCHEMA = ROOT / "src" / "certification" / "manifest.schema.json"
+INVENTORY = ROOT / "src" / "certification" / "evidence-inventory.json"
+PACK_TIMEOUT_SECONDS = 180
+GENERATOR_TIMEOUT_SECONDS = 120
+
+
+def pack_tarball(destination: Path) -> Path:
+    completed = subprocess.run(
+        ["npm", "pack", "--json", "--pack-destination", str(destination)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=PACK_TIMEOUT_SECONDS,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(f"npm pack failed: {completed.stderr}")
+    payload = json.loads(completed.stdout)
+    tarball = destination / payload[0]["filename"]
+    if not tarball.is_file():
+        raise AssertionError(f"npm pack produced no tarball at {tarball}")
+    return tarball
+
+
+def run_generator(*extra_args: str, **paths: str) -> subprocess.CompletedProcess:
+    command = [
+        sys.executable,
+        str(SCRIPT),
+        "--package",
+        paths["package"],
+        "--output",
+        paths["output"],
+    ]
+    if "inventory" in paths:
+        command += ["--inventory", paths["inventory"]]
+    command += list(extra_args)
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=GENERATOR_TIMEOUT_SECONDS,
+    )
+
+
+class CertificationManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._scratch = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls._scratch.cleanup)
+        scratch = Path(cls._scratch.name)
+        cls.tarball = pack_tarball(scratch)
+        cls.output = scratch / "certification-manifest.json"
+        completed = run_generator(package=str(cls.tarball), output=str(cls.output))
+        if completed.returncode != 0:
+            raise AssertionError(completed.stderr)
+        cls.manifest = json.loads(cls.output.read_text(encoding="utf-8"))
+        cls.schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+
+    def test_generated_manifest_validates_against_the_schema(self) -> None:
+        errors = list(
+            Draft202012Validator(self.schema).iter_errors(self.manifest)
+        )
+        self.assertEqual(errors, [], [error.message for error in errors])
+
+    def test_manifest_reflects_the_current_component_set(self) -> None:
+        inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+        expected = {
+            (component["slug"], inventory["profiles"][component["profile"]]["tier"])
+            for component in inventory["components"]
+        }
+        actual = {
+            (component["slug"], component["tier"])
+            for component in self.manifest["certifiedComponents"]
+        }
+        self.assertEqual(actual, expected)
+        self.assertEqual(len(self.manifest["certifiedComponents"]), 42)
+        self.assertEqual(self.manifest["status"], "preview")
+        package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+        self.assertEqual(self.manifest["coreVersion"], package["version"])
+
+    def test_missing_evidence_fails_loudly(self) -> None:
+        inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+        inventory["components"][0]["evidence"].append(
+            "tests/_manifest_fault_injection_missing.py"
+        )
+        with tempfile.TemporaryDirectory() as scratch:
+            bad_inventory = Path(scratch) / "broken-inventory.json"
+            bad_inventory.write_text(
+                json.dumps(inventory), encoding="utf-8"
+            )
+            completed = run_generator(
+                package=str(self.tarball),
+                output=str(Path(scratch) / "out.json"),
+                inventory=str(bad_inventory),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("missing evidence", completed.stderr)
+
+    def test_empty_evidence_fails_loudly(self) -> None:
+        inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+        inventory["components"][0]["evidence"] = []
+        with tempfile.TemporaryDirectory() as scratch:
+            bad_inventory = Path(scratch) / "broken-inventory.json"
+            bad_inventory.write_text(
+                json.dumps(inventory), encoding="utf-8"
+            )
+            completed = run_generator(
+                package=str(self.tarball),
+                output=str(Path(scratch) / "out.json"),
+                inventory=str(bad_inventory),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("has no evidence", completed.stderr)
+
+    def test_evidence_escaping_the_repository_fails_loudly(self) -> None:
+        inventory = json.loads(INVENTORY.read_text(encoding="utf-8"))
+        inventory["components"][0]["evidence"].append("../../../../etc/hosts")
+        with tempfile.TemporaryDirectory() as scratch:
+            bad_inventory = Path(scratch) / "broken-inventory.json"
+            bad_inventory.write_text(
+                json.dumps(inventory), encoding="utf-8"
+            )
+            completed = run_generator(
+                package=str(self.tarball),
+                output=str(Path(scratch) / "out.json"),
+                inventory=str(bad_inventory),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("escapes the repository", completed.stderr)
+
+    def test_output_aliasing_the_package_fails_loudly(self) -> None:
+        completed = run_generator(
+            package=str(self.tarball),
+            output=str(self.tarball),
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("must not name the package tarball", completed.stderr)
+        self.assertTrue(self.tarball.is_file())
+
+    def test_certified_status_requires_release_attestation_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            completed = run_generator(
+                "--status",
+                "certified",
+                package=str(self.tarball),
+                output=str(Path(scratch) / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("--source-commit", completed.stderr)
+
+    def test_package_hash_mismatch_fails_loudly(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            completed = run_generator(
+                "--expected-package-sha256",
+                "0" * 64,
+                package=str(self.tarball),
+                output=str(Path(scratch) / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("package hash mismatch", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_certification_manifest.py
+++ b/tests/test_certification_manifest.py
@@ -81,6 +81,81 @@ class CertificationManifestTests(unittest.TestCase):
             raise AssertionError(completed.stderr)
         cls.manifest = json.loads(cls.output.read_text(encoding="utf-8"))
         cls.schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+        cls.head_commit = cls._head_commit()
+        cls.package_sha256 = hashlib.sha256(cls.tarball.read_bytes()).hexdigest()
+        cls.core_version = json.loads(
+            (ROOT / "package.json").read_text(encoding="utf-8")
+        )["version"]
+
+    @staticmethod
+    def _head_commit() -> str:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=GENERATOR_TIMEOUT_SECONDS,
+        ).stdout.strip()
+
+    def _certified_attestation_document(self, **overrides: object) -> dict:
+        """A schema-valid status="certified" attestation matching this
+        class's tarball/commit/version by default. Every certified-status
+        test below should build from this (via overrides) rather than a
+        hand-rolled document, so a test actually exercises the manifest
+        generator's cross-checks instead of tripping schema validation
+        first for an unrelated reason."""
+        document = {
+            "schemaVersion": "0.1",
+            "status": "certified",
+            "scope": "core",
+            "coreVersion": self.core_version,
+            "sourceCommit": self.head_commit,
+            "createdAt": "2026-08-06T00:00:00Z",
+            "result": "passed",
+            "package": {
+                "name": "@wpmoo/ui",
+                "version": self.core_version,
+                "filename": self.tarball.name,
+                "sha256": self.package_sha256,
+                "manifestSha256": "0" * 64,
+            },
+            "bootstrap": [
+                {"lane": "canonical", "version": "5.3.3", "result": "passed"}
+            ],
+            "browsers": [
+                {
+                    "name": "Chromium",
+                    "version": "test",
+                    "operatingSystem": "test",
+                    "mode": "automated",
+                    "result": "passed",
+                }
+            ],
+            "components": [],
+            "automatedRuns": [
+                {
+                    "name": "test-harness",
+                    "result": "passed",
+                    "evidence": "urn:test:manifest-certified-status",
+                }
+            ],
+            "manualReviews": [],
+            "realDevices": [],
+            "waivers": [],
+            "limitations": [],
+        }
+        document.update(overrides)
+        return document
+
+    def _write_certified_attestation(
+        self, scratch_path: Path, **overrides: object
+    ) -> tuple[Path, str]:
+        document = self._certified_attestation_document(**overrides)
+        attestation_path = scratch_path / "attestation.json"
+        content = json.dumps(document).encode("utf-8")
+        attestation_path.write_bytes(content)
+        return attestation_path, hashlib.sha256(content).hexdigest()
 
     def test_generated_manifest_validates_against_the_schema(self) -> None:
         errors = list(
@@ -175,19 +250,12 @@ class CertificationManifestTests(unittest.TestCase):
         self.assertIn("--source-commit", completed.stderr)
 
     def test_certified_status_requires_an_attestation_file_not_just_a_uri(self) -> None:
-        head_commit = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
         with tempfile.TemporaryDirectory() as scratch:
             completed = run_generator(
                 "--status",
                 "certified",
                 "--source-commit",
-                head_commit,
+                self.head_commit,
                 "--attestation",
                 "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
                 package=str(self.tarball),
@@ -196,42 +264,81 @@ class CertificationManifestTests(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("--attestation-file", completed.stderr)
 
-    def test_certified_status_rejects_a_mismatched_attestation(self) -> None:
-        head_commit = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
+    def test_certified_status_requires_a_matching_attestation_sha256(self) -> None:
         with tempfile.TemporaryDirectory() as scratch:
             scratch_path = Path(scratch)
-            forged = scratch_path / "attestation.json"
-            forged.write_text(
-                json.dumps(
-                    {
-                        "sourceCommit": "a" * 40,  # does not match head_commit
-                        "coreVersion": "0.0.0",
-                        "result": "passed",
-                        "package": {"sha256": "b" * 64},
-                    }
-                ),
-                encoding="utf-8",
-            )
+            attestation_path, _ = self._write_certified_attestation(scratch_path)
             completed = run_generator(
                 "--status",
                 "certified",
                 "--source-commit",
-                head_commit,
+                self.head_commit,
+                "--attestation",
+                "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("--attestation-sha256", completed.stderr)
+
+    def test_certified_status_rejects_a_schema_invalid_attestation(self) -> None:
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            forged = scratch_path / "attestation.json"
+            content = json.dumps(
+                {
+                    "sourceCommit": "a" * 40,
+                    "coreVersion": "0.0.0",
+                    "result": "passed",
+                    "package": {"sha256": "b" * 64},
+                }
+            ).encode("utf-8")
+            forged.write_bytes(content)
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                self.head_commit,
                 "--attestation",
                 "https://example.invalid/attestation.json",
                 "--attestation-file",
                 str(forged),
+                "--attestation-sha256",
+                hashlib.sha256(content).hexdigest(),
                 package=str(self.tarball),
                 output=str(scratch_path / "out.json"),
             )
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("does not conform to attestation.schema.json", completed.stderr)
+
+    def test_certified_status_rejects_a_valid_attestation_for_another_commit(self) -> None:
+        # Schema-valid and hash-matched, but sourceCommit points elsewhere -
+        # this is the case the earlier schema-invalid test could not reach,
+        # since an incomplete document fails schema validation first.
+        foreign_commit = "a" * 40 if self.head_commit != "a" * 40 else "b" * 40
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path, attestation_sha256 = self._write_certified_attestation(
+                scratch_path, sourceCommit=foreign_commit
+            )
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                self.head_commit,
+                "--attestation",
+                "https://example.invalid/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                "--attestation-sha256",
+                attestation_sha256,
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("sourceCommit does not match", completed.stderr)
 
     def test_package_hash_mismatch_fails_loudly(self) -> None:
         with tempfile.TemporaryDirectory() as scratch:
@@ -250,13 +357,6 @@ class CertificationManifestTests(unittest.TestCase):
         # manifest input) - a real, correctly-generated, passing attestation
         # must still be refused as certified backing, because it never
         # claimed to be one.
-        head_commit = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
         with tempfile.TemporaryDirectory() as scratch:
             scratch_path = Path(scratch)
             attestation_path = scratch_path / "attestation.json"
@@ -269,7 +369,7 @@ class CertificationManifestTests(unittest.TestCase):
                     "--output",
                     str(attestation_path),
                     "--source-commit",
-                    head_commit,
+                    self.head_commit,
                     "--browser-name",
                     "test-harness",
                     "--browser-version",
@@ -288,18 +388,21 @@ class CertificationManifestTests(unittest.TestCase):
             self.assertEqual(
                 attestation_completed.returncode, 0, attestation_completed.stderr
             )
-            attestation = json.loads(attestation_path.read_text(encoding="utf-8"))
+            attestation_bytes = attestation_path.read_bytes()
+            attestation = json.loads(attestation_bytes.decode("utf-8"))
             self.assertEqual(attestation["status"], "preview")
 
             completed = run_generator(
                 "--status",
                 "certified",
                 "--source-commit",
-                head_commit,
+                self.head_commit,
                 "--attestation",
                 "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
                 "--attestation-file",
                 str(attestation_path),
+                "--attestation-sha256",
+                hashlib.sha256(attestation_bytes).hexdigest(),
                 package=str(self.tarball),
                 output=str(scratch_path / "out.json"),
             )
@@ -312,62 +415,10 @@ class CertificationManifestTests(unittest.TestCase):
         # generate. This constructs a schema-valid certified attestation
         # by hand to test the manifest generator's own validation in
         # isolation from that still-missing upstream generator.
-        head_commit = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
-        package_sha256 = hashlib.sha256(self.tarball.read_bytes()).hexdigest()
-        core_version = json.loads(
-            (ROOT / "package.json").read_text(encoding="utf-8")
-        )["version"]
-        certified_attestation_document = {
-            "schemaVersion": "0.1",
-            "status": "certified",
-            "scope": "core",
-            "coreVersion": core_version,
-            "sourceCommit": head_commit,
-            "createdAt": "2026-08-06T00:00:00Z",
-            "result": "passed",
-            "package": {
-                "name": "@wpmoo/ui",
-                "version": core_version,
-                "filename": self.tarball.name,
-                "sha256": package_sha256,
-                "manifestSha256": "0" * 64,
-            },
-            "bootstrap": [
-                {"lane": "canonical", "version": "5.3.3", "result": "passed"}
-            ],
-            "browsers": [
-                {
-                    "name": "Chromium",
-                    "version": "test",
-                    "operatingSystem": "test",
-                    "mode": "automated",
-                    "result": "passed",
-                }
-            ],
-            "components": [],
-            "automatedRuns": [
-                {
-                    "name": "test-harness",
-                    "result": "passed",
-                    "evidence": "urn:test:manifest-certified-status",
-                }
-            ],
-            "manualReviews": [],
-            "realDevices": [],
-            "waivers": [],
-            "limitations": [],
-        }
         with tempfile.TemporaryDirectory() as scratch:
             scratch_path = Path(scratch)
-            attestation_path = scratch_path / "attestation.json"
-            attestation_path.write_text(
-                json.dumps(certified_attestation_document), encoding="utf-8"
+            attestation_path, attestation_sha256 = self._write_certified_attestation(
+                scratch_path
             )
 
             output_path = scratch_path / "out.json"
@@ -375,11 +426,13 @@ class CertificationManifestTests(unittest.TestCase):
                 "--status",
                 "certified",
                 "--source-commit",
-                head_commit,
+                self.head_commit,
                 "--attestation",
                 "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
                 "--attestation-file",
                 str(attestation_path),
+                "--attestation-sha256",
+                attestation_sha256,
                 package=str(self.tarball),
                 output=str(output_path),
             )
@@ -387,7 +440,7 @@ class CertificationManifestTests(unittest.TestCase):
             manifest = json.loads(output_path.read_text(encoding="utf-8"))
 
         self.assertEqual(manifest["status"], "certified")
-        self.assertEqual(manifest["sourceCommit"], head_commit)
+        self.assertEqual(manifest["sourceCommit"], self.head_commit)
         errors = list(
             Draft202012Validator(
                 json.loads(SCHEMA.read_text(encoding="utf-8"))

--- a/tests/test_certification_manifest.py
+++ b/tests/test_certification_manifest.py
@@ -9,6 +9,7 @@ under-reporting manifest would be worse than no manifest.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import sys
@@ -243,7 +244,12 @@ class CertificationManifestTests(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("package hash mismatch", completed.stderr)
 
-    def test_certified_status_accepts_a_real_matching_attestation(self) -> None:
+    def test_certified_status_rejects_a_real_preview_attestation(self) -> None:
+        # scripts/build-certification-attestation.py only ever emits
+        # status="preview" by design (it explicitly rejects non-preview
+        # manifest input) - a real, correctly-generated, passing attestation
+        # must still be refused as certified backing, because it never
+        # claimed to be one.
         head_commit = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=ROOT,
@@ -281,6 +287,87 @@ class CertificationManifestTests(unittest.TestCase):
             )
             self.assertEqual(
                 attestation_completed.returncode, 0, attestation_completed.stderr
+            )
+            attestation = json.loads(attestation_path.read_text(encoding="utf-8"))
+            self.assertEqual(attestation["status"], "preview")
+
+            completed = run_generator(
+                "--status",
+                "certified",
+                "--source-commit",
+                head_commit,
+                "--attestation",
+                "https://github.com/wpmoo-org/ui/releases/download/v1.0.0/attestation.json",
+                "--attestation-file",
+                str(attestation_path),
+                package=str(self.tarball),
+                output=str(scratch_path / "out.json"),
+            )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("not 'certified'", completed.stderr)
+
+    def test_certified_status_accepts_a_matching_certified_attestation(self) -> None:
+        # No tool in this repo produces status="certified" yet - that
+        # requires the human/manual-acceptance evidence Phase 6 doesn't
+        # generate. This constructs a schema-valid certified attestation
+        # by hand to test the manifest generator's own validation in
+        # isolation from that still-missing upstream generator.
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        package_sha256 = hashlib.sha256(self.tarball.read_bytes()).hexdigest()
+        core_version = json.loads(
+            (ROOT / "package.json").read_text(encoding="utf-8")
+        )["version"]
+        certified_attestation_document = {
+            "schemaVersion": "0.1",
+            "status": "certified",
+            "scope": "core",
+            "coreVersion": core_version,
+            "sourceCommit": head_commit,
+            "createdAt": "2026-08-06T00:00:00Z",
+            "result": "passed",
+            "package": {
+                "name": "@wpmoo/ui",
+                "version": core_version,
+                "filename": self.tarball.name,
+                "sha256": package_sha256,
+                "manifestSha256": "0" * 64,
+            },
+            "bootstrap": [
+                {"lane": "canonical", "version": "5.3.3", "result": "passed"}
+            ],
+            "browsers": [
+                {
+                    "name": "Chromium",
+                    "version": "test",
+                    "operatingSystem": "test",
+                    "mode": "automated",
+                    "result": "passed",
+                }
+            ],
+            "components": [],
+            "automatedRuns": [
+                {
+                    "name": "test-harness",
+                    "result": "passed",
+                    "evidence": "urn:test:manifest-certified-status",
+                }
+            ],
+            "manualReviews": [],
+            "realDevices": [],
+            "waivers": [],
+            "limitations": [],
+        }
+        with tempfile.TemporaryDirectory() as scratch:
+            scratch_path = Path(scratch)
+            attestation_path = scratch_path / "attestation.json"
+            attestation_path.write_text(
+                json.dumps(certified_attestation_document), encoding="utf-8"
             )
 
             output_path = scratch_path / "out.json"

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -1,0 +1,44 @@
+"""Lock the RC rehearsal script: it must run clean against the current
+tree and never touch npm publish, npm version, or git tags.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+from tests.helpers import ROOT
+
+SCRIPT = ROOT / "scripts" / "rehearse-rc.py"
+RUN_TIMEOUT_SECONDS = 300
+
+
+class RehearseRcTests(unittest.TestCase):
+    def test_rehearsal_runs_clean_and_never_publishes(self) -> None:
+        # Only the executable body is checked — the module docstring
+        # legitimately explains what the script avoids doing.
+        source = SCRIPT.read_text(encoding="utf-8")
+        _, _, body = source.partition('"""\n\nfrom __future__')
+        self.assertTrue(body, "could not isolate the script body from its docstring")
+        # Matches the quoted argv token regardless of list-literal spacing,
+        # e.g. both ["npm", "publish"] and ["npm","publish"].
+        for forbidden in ('"publish"', '"push"', '"tag"'):
+            self.assertNotIn(forbidden, body, forbidden)
+
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=RUN_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("REHEARSAL OK", completed.stdout)
+        self.assertIn("package version:", completed.stdout)
+        self.assertIn("source commit:", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -61,13 +61,16 @@ class RehearseRcTests(unittest.TestCase):
 
         # Stage B is fully wired now that Phase 6 Tasks 1 and 2 have both
         # landed - assert the summary names each generator's real output
-        # path, rather than merely that it doesn't say "pending"; a script
-        # that renamed the placeholder text would slip past a negative
-        # check but not this one.
+        # path and that the file actually exists, rather than merely that
+        # it doesn't say "pending"; a script that renamed the placeholder
+        # text, or reported a path it never wrote, would slip past a
+        # padded-text-only check but not this one.
         manifest_path = OUT_DIR / "certification-manifest.json"
         attestation_path = OUT_DIR / "certification-attestation.json"
-        self.assertIn(f"manifest:        {manifest_path}", self.completed.stdout)
-        self.assertIn(f"attestation:     {attestation_path}", self.completed.stdout)
+        self.assertIn(str(manifest_path), self.completed.stdout)
+        self.assertTrue(manifest_path.is_file(), manifest_path)
+        self.assertIn(str(attestation_path), self.completed.stdout)
+        self.assertTrue(attestation_path.is_file(), attestation_path)
 
     def test_artifacts_agree_on_version_and_source_commit(self) -> None:
         self.assertEqual(self.completed.returncode, 0, self.completed.stderr)

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -7,6 +7,7 @@ rather than trusted from the script's own summary line.
 
 from __future__ import annotations
 
+import ast
 import json
 import subprocess
 import sys
@@ -38,17 +39,38 @@ class RehearseRcTests(unittest.TestCase):
         # Only the executable body is checked — the module docstring
         # legitimately explains what the script avoids doing.
         self.assertTrue(self.body, "could not isolate the script body from its docstring")
-        # Matches the quoted argv token regardless of list-literal spacing,
-        # e.g. both ["npm", "publish"] and ["npm","publish"].
-        for forbidden in ('"publish"', '"push"', '"tag"'):
-            self.assertNotIn(forbidden, self.body, forbidden)
+        # AST-based rather than textual: a plain substring/token search on
+        # "version" also matches package.json's ["version"] key lookup,
+        # which has nothing to do with `npm version`. Instead, walk every
+        # list literal in the script and flag any that pairs "npm" with a
+        # mutating subcommand - the actual argv shape a subprocess call
+        # would use. Parsed from the full source (not self.body) since a
+        # module docstring is a single string node, not a list literal, so
+        # stripping it isn't necessary for this check.
+        forbidden = {"publish", "push", "tag", "version"}
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.List):
+                continue
+            elements = [
+                element.value
+                for element in node.elts
+                if isinstance(element, ast.Constant) and isinstance(element.value, str)
+            ]
+            if "npm" not in elements:
+                continue
+            hit = forbidden.intersection(elements)
+            self.assertFalse(hit, f"npm argv list contains forbidden token(s): {hit}")
 
         self.assertEqual(self.completed.returncode, 0, self.completed.stderr)
         self.assertIn("REHEARSAL OK", self.completed.stdout)
 
         # Stage B is fully wired now that Phase 6 Tasks 1 and 2 have both
         # landed - neither generator should be reported pending anymore.
-        self.assertNotIn("pending", self.completed.stdout)
+        # Matched against the script's own literal status lines rather than
+        # the bare word "pending", so unrelated output can't collide.
+        self.assertNotIn("manifest:        pending", self.completed.stdout)
+        self.assertNotIn("attestation:     pending", self.completed.stdout)
 
     def test_artifacts_agree_on_version_and_source_commit(self) -> None:
         self.assertEqual(self.completed.returncode, 0, self.completed.stderr)

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -8,6 +8,7 @@ rather than trusted from the script's own summary line.
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
 import subprocess
 import sys
@@ -18,7 +19,12 @@ from tests.helpers import ROOT
 
 SCRIPT = ROOT / "scripts" / "rehearse-rc.py"
 OUT_DIR = ROOT / "dist" / "rc-rehearsal"
-RUN_TIMEOUT_SECONDS = 300
+# Generous relative to rehearse-rc.py's own internal DEFAULT_TIMEOUT_SECONDS
+# (600s per command): the script runs several such commands in sequence on
+# a cold cache (build.py, two npm packs, two npm installs, the conformance
+# kit, and both certification generators), so the outer budget must cover
+# more than one worst-case internal timeout.
+RUN_TIMEOUT_SECONDS = 900
 
 
 class RehearseRcTests(unittest.TestCase):
@@ -75,7 +81,8 @@ class RehearseRcTests(unittest.TestCase):
     def test_artifacts_agree_on_version_and_source_commit(self) -> None:
         self.assertEqual(self.completed.returncode, 0, self.completed.stderr)
 
-        with tarfile.open(next(OUT_DIR.glob("*.tgz"))) as archive:
+        tarball = next(OUT_DIR.glob("*.tgz"))
+        with tarfile.open(tarball) as archive:
             package = json.loads(
                 archive.extractfile("package/package.json").read()
             )
@@ -97,6 +104,10 @@ class RehearseRcTests(unittest.TestCase):
         self.assertEqual(package["version"], manifest["coreVersion"])
         self.assertEqual(package["version"], attestation["coreVersion"])
         self.assertEqual(attestation["sourceCommit"], head_commit)
+        self.assertEqual(
+            attestation["package"]["sha256"],
+            hashlib.sha256(tarball.read_bytes()).hexdigest(),
+        )
         self.assertEqual(len(manifest["certifiedComponents"]), 42)
         self.assertEqual(len(attestation["components"]), 42)
 

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -60,11 +60,14 @@ class RehearseRcTests(unittest.TestCase):
         self.assertIn("REHEARSAL OK", self.completed.stdout)
 
         # Stage B is fully wired now that Phase 6 Tasks 1 and 2 have both
-        # landed - neither generator should be reported pending anymore.
-        # Matched against the script's own literal status lines rather than
-        # the bare word "pending", so unrelated output can't collide.
-        self.assertNotIn("manifest:        pending", self.completed.stdout)
-        self.assertNotIn("attestation:     pending", self.completed.stdout)
+        # landed - assert the summary names each generator's real output
+        # path, rather than merely that it doesn't say "pending"; a script
+        # that renamed the placeholder text would slip past a negative
+        # check but not this one.
+        manifest_path = OUT_DIR / "certification-manifest.json"
+        attestation_path = OUT_DIR / "certification-attestation.json"
+        self.assertIn(f"manifest:        {manifest_path}", self.completed.stdout)
+        self.assertIn(f"attestation:     {attestation_path}", self.completed.stdout)
 
     def test_artifacts_agree_on_version_and_source_commit(self) -> None:
         self.assertEqual(self.completed.returncode, 0, self.completed.stderr)

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import tarfile
 import unittest
-from pathlib import Path
 
 from tests.helpers import ROOT
 
@@ -25,8 +24,6 @@ RUN_TIMEOUT_SECONDS = 300
 class RehearseRcTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        source = SCRIPT.read_text(encoding="utf-8")
-        _, _, cls.body = source.partition('"""\n\nfrom __future__')
         cls.completed = subprocess.run(
             [sys.executable, str(SCRIPT)],
             cwd=ROOT,
@@ -36,17 +33,14 @@ class RehearseRcTests(unittest.TestCase):
         )
 
     def test_rehearsal_runs_clean_and_never_publishes(self) -> None:
-        # Only the executable body is checked — the module docstring
-        # legitimately explains what the script avoids doing.
-        self.assertTrue(self.body, "could not isolate the script body from its docstring")
         # AST-based rather than textual: a plain substring/token search on
         # "version" also matches package.json's ["version"] key lookup,
         # which has nothing to do with `npm version`. Instead, walk every
         # list literal in the script and flag any that pairs "npm" with a
         # mutating subcommand - the actual argv shape a subprocess call
-        # would use. Parsed from the full source (not self.body) since a
-        # module docstring is a single string node, not a list literal, so
-        # stripping it isn't necessary for this check.
+        # would use. A module docstring is a single string node, not a
+        # list literal, so it can't trip this even though it legitimately
+        # names the same words while explaining what the script avoids.
         forbidden = {"publish", "push", "tag", "version"}
         tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
         for node in ast.walk(tree):

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -1,54 +1,82 @@
 """Lock the RC rehearsal script: it must run clean against the current
-tree and never touch npm publish, npm version, or git tags.
+tree, never touch npm publish/version/tag/push, and produce a tarball,
+conformance kit, manifest, and attestation that all agree on version and
+source commit — Task 4's actual acceptance criterion, checked directly
+rather than trusted from the script's own summary line.
 """
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
+import tarfile
 import unittest
 from pathlib import Path
 
 from tests.helpers import ROOT
 
 SCRIPT = ROOT / "scripts" / "rehearse-rc.py"
+OUT_DIR = ROOT / "dist" / "rc-rehearsal"
 RUN_TIMEOUT_SECONDS = 300
 
 
 class RehearseRcTests(unittest.TestCase):
-    def test_rehearsal_runs_clean_and_never_publishes(self) -> None:
-        # Only the executable body is checked — the module docstring
-        # legitimately explains what the script avoids doing.
+    @classmethod
+    def setUpClass(cls) -> None:
         source = SCRIPT.read_text(encoding="utf-8")
-        _, _, body = source.partition('"""\n\nfrom __future__')
-        self.assertTrue(body, "could not isolate the script body from its docstring")
-        # Matches the quoted argv token regardless of list-literal spacing,
-        # e.g. both ["npm", "publish"] and ["npm","publish"].
-        for forbidden in ('"publish"', '"push"', '"tag"'):
-            self.assertNotIn(forbidden, body, forbidden)
-
-        completed = subprocess.run(
+        _, _, cls.body = source.partition('"""\n\nfrom __future__')
+        cls.completed = subprocess.run(
             [sys.executable, str(SCRIPT)],
             cwd=ROOT,
             capture_output=True,
             text=True,
             timeout=RUN_TIMEOUT_SECONDS,
         )
-        self.assertEqual(completed.returncode, 0, completed.stderr)
-        self.assertIn("REHEARSAL OK", completed.stdout)
-        self.assertIn("package version:", completed.stdout)
-        self.assertIn("source commit:", completed.stdout)
 
-        # Stage B, Task 1 half: the manifest generator exists as of Phase 6
-        # Task 1, so the rehearsal must actually produce a manifest, not
-        # just report it pending.
-        self.assertIn("manifest:        " + str(ROOT), completed.stdout)
-        self.assertNotIn("manifest:        pending", completed.stdout)
+    def test_rehearsal_runs_clean_and_never_publishes(self) -> None:
+        # Only the executable body is checked — the module docstring
+        # legitimately explains what the script avoids doing.
+        self.assertTrue(self.body, "could not isolate the script body from its docstring")
+        # Matches the quoted argv token regardless of list-literal spacing,
+        # e.g. both ["npm", "publish"] and ["npm","publish"].
+        for forbidden in ('"publish"', '"push"', '"tag"'):
+            self.assertNotIn(forbidden, self.body, forbidden)
 
-        # Stage B, Task 2 half: the attestation generator still reads
-        # pilot-evidence.json until Task 2 re-scopes it, so the rehearsal
-        # must keep reporting it pending rather than wiring in stale data.
-        self.assertIn("attestation:     pending", completed.stdout)
+        self.assertEqual(self.completed.returncode, 0, self.completed.stderr)
+        self.assertIn("REHEARSAL OK", self.completed.stdout)
+
+        # Stage B is fully wired now that Phase 6 Tasks 1 and 2 have both
+        # landed - neither generator should be reported pending anymore.
+        self.assertNotIn("pending", self.completed.stdout)
+
+    def test_artifacts_agree_on_version_and_source_commit(self) -> None:
+        self.assertEqual(self.completed.returncode, 0, self.completed.stderr)
+
+        with tarfile.open(next(OUT_DIR.glob("*.tgz"))) as archive:
+            package = json.loads(
+                archive.extractfile("package/package.json").read()
+            )
+        manifest = json.loads(
+            (OUT_DIR / "certification-manifest.json").read_text(encoding="utf-8")
+        )
+        attestation = json.loads(
+            (OUT_DIR / "certification-attestation.json").read_text(encoding="utf-8")
+        )
+
+        head_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        self.assertEqual(package["version"], manifest["coreVersion"])
+        self.assertEqual(package["version"], attestation["coreVersion"])
+        self.assertEqual(attestation["sourceCommit"], head_commit)
+        self.assertEqual(len(manifest["certifiedComponents"]), 42)
+        self.assertEqual(len(attestation["components"]), 42)
 
 
 if __name__ == "__main__":

--- a/tests/test_rehearse_rc.py
+++ b/tests/test_rehearse_rc.py
@@ -39,6 +39,17 @@ class RehearseRcTests(unittest.TestCase):
         self.assertIn("package version:", completed.stdout)
         self.assertIn("source commit:", completed.stdout)
 
+        # Stage B, Task 1 half: the manifest generator exists as of Phase 6
+        # Task 1, so the rehearsal must actually produce a manifest, not
+        # just report it pending.
+        self.assertIn("manifest:        " + str(ROOT), completed.stdout)
+        self.assertNotIn("manifest:        pending", completed.stdout)
+
+        # Stage B, Task 2 half: the attestation generator still reads
+        # pilot-evidence.json until Task 2 re-scopes it, so the rehearsal
+        # must keep reporting it pending rather than wiring in stale data.
+        self.assertIn("attestation:     pending", completed.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Phase 6 (1.0.0-rc.1 preparation). Work-in-progress: merge only after Tasks 5 and 6 land and the temporary nightly trigger is removed.

## Landed so far (this PR)

- **Task 1** — Certification manifest generator (`scripts/build-certification-manifest.py`), stdlib-only, fail-loud evidence checks, schema-validation test with fault injection.
- **Task 2** — Attestation generator re-scoped in place to Core-only evidence (`evidence-inventory.json`, scope=core, 42 components) with HEAD provenance binding; decision recorded in DECISIONS.md (parent repo).
- **Task 3** — Nightly cross-browser certification matrix (`.github/workflows/nightly.yml`): chromium/firefox/webkit, cron 03:30 UTC + workflow_dispatch; harness made engine-aware (MOO_UI_BROWSER_ENGINE, Firefox isMobile guard) with engine-selection tests.
- **Task 4** (Claude) — RC tarball build-and-test rehearsal wired to the Task 1 manifest and Task 2 attestation generators.

## Task 3 temporary trigger

`nightly.yml` carries a temporary `pull_request:` trigger so the matrix runs for real as a check on this PR (GitHub only registers workflows from the default branch, so it cannot be dispatched while it lives only on dev). This block MUST be removed in the final commit before merge.

## Pending

- Task 5 — manual acceptance checklist draft
- Task 6 — clean install + migration rehearsal record

Full local suite: 754 tests OK (skipped=1). CI re-verifies at the PR head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nightly and on-demand browser certification for Chromium, Firefox, and WebKit.
  * Added certification manifest and attestation generation tools.
  * Added release-candidate rehearsal checks without publishing.

* **Improvements**
  * Strengthened certification and artifact validation across 42 Core components.
  * Expanded Firefox and WebKit compatibility testing.
  * Improved inline-code styling and contrast across catalog pages.

* **Documentation**
  * Added manual acceptance and clean-install rehearsal documentation.

* **Tests**
  * Added browser, certification, manifest, and release-rehearsal coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->