### PR TITLE
npm-publish.yml must never tag a prerelease as npm's latest

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -78,6 +78,17 @@ jobs:
           echo "name=${name}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          # A prerelease identifier (e.g. "1.0.0-rc.1") must never publish
+          # under npm's default "latest" dist-tag, or every plain
+          # `npm install @wpmoo/ui` would suddenly resolve to a
+          # release candidate instead of the last stable version.
+          if [[ "${version}" == *-* ]]; then
+            echo "npm_tag=rc" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
           if [ -n "${RELEASE_REF}" ]; then
             if ! git show-ref --verify --quiet "refs/tags/${tag}"; then
               echo "Release ref ${tag} must be an existing tag."
@@ -115,7 +126,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.package.outputs.published == 'false'
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag "${{ steps.package.outputs.npm_tag }}"
 
       - name: Create GitHub release notes
         if: startsWith(steps.package.outputs.tag, 'v')
@@ -124,7 +135,11 @@ jobs:
           if gh release view "${tag}" >/dev/null 2>&1; then
             echo "Release ${tag} already exists; skipping."
           else
-            gh release create "${tag}" --title "${tag}" --generate-notes
+            release_args=("${tag}" --title "${tag}" --generate-notes)
+            if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then
+              release_args+=(--prerelease)
+            fi
+            gh release create "${release_args[@]}"
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -563,9 +563,10 @@ for (const specifier of [
                     )
                     self.assertEqual(completed.returncode, 0, completed.stderr)
                     outputs = output_path.read_text(encoding="utf-8")
-                    self.assertIn(f"npm_tag={expected_npm_tag}\n", outputs)
-                    self.assertIn(
-                        f"prerelease={expected_prerelease}\n", outputs
+                    self.assertEqual(
+                        outputs,
+                        f"npm_tag={expected_npm_tag}\n"
+                        f"prerelease={expected_prerelease}\n",
                     )
 
         self.assertIn(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -529,25 +530,43 @@ for (const specifier of [
         # A version like "1.0.0-rc.1" must publish under a dist-tag other
         # than npm's default "latest" - otherwise a plain `npm install
         # @wpmoo/ui` would resolve to a release candidate instead of the
-        # last stable release the moment an RC tag is pushed. Split on the
-        # if/else/fi markers so each output pair is checked inside its own
-        # branch, not just present somewhere in the file - a swapped
-        # npm_tag/prerelease pair between branches would otherwise still
-        # pass a plain assertIn check.
+        # last stable release the moment an RC tag is pushed. Extract the
+        # exact routing snippet and actually execute it for a stable and a
+        # prerelease version, asserting on its real GITHUB_OUTPUT writes -
+        # a text/position check could still pass a logic bug (e.g. an
+        # inverted comparison) that happens to keep the right literal
+        # strings in the right branches.
         marker = 'if [[ "${version}" == *-* ]]; then'
         self.assertIn(marker, workflow)
-        _, _, after_if = workflow.partition(marker)
-        prerelease_branch, has_else, after_else = after_if.partition("\n          else\n")
-        self.assertTrue(has_else, "expected an else branch immediately after the if")
-        stable_branch, has_fi, _ = after_else.partition("\n          fi\n")
-        self.assertTrue(has_fi, "expected a closing fi for the version-check if")
+        start = workflow.index(marker)
+        end = workflow.index("\n          fi\n", start) + len("\n          fi\n")
+        routing_snippet = workflow[start:end]
 
-        self.assertIn('echo "npm_tag=rc" >> "$GITHUB_OUTPUT"', prerelease_branch)
-        self.assertIn('echo "prerelease=true" >> "$GITHUB_OUTPUT"', prerelease_branch)
-        self.assertIn('echo "npm_tag=latest" >> "$GITHUB_OUTPUT"', stable_branch)
-        self.assertIn('echo "prerelease=false" >> "$GITHUB_OUTPUT"', stable_branch)
-        self.assertNotIn("npm_tag=latest", prerelease_branch)
-        self.assertNotIn("npm_tag=rc", stable_branch)
+        for version, expected_npm_tag, expected_prerelease in (
+            ("1.0.0-rc.1", "rc", "true"),
+            ("1.0.0", "latest", "false"),
+        ):
+            with self.subTest(version=version):
+                with tempfile.TemporaryDirectory() as scratch:
+                    output_path = Path(scratch) / "github_output"
+                    output_path.write_text("", encoding="utf-8")
+                    completed = subprocess.run(
+                        ["bash", "-c", routing_snippet],
+                        env={
+                            **os.environ,
+                            "version": version,
+                            "GITHUB_OUTPUT": str(output_path),
+                        },
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                    )
+                    self.assertEqual(completed.returncode, 0, completed.stderr)
+                    outputs = output_path.read_text(encoding="utf-8")
+                    self.assertIn(f"npm_tag={expected_npm_tag}\n", outputs)
+                    self.assertIn(
+                        f"prerelease={expected_prerelease}\n", outputs
+                    )
 
         self.assertIn(
             'npm publish --access public --provenance --tag '

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -529,10 +529,26 @@ for (const specifier of [
         # A version like "1.0.0-rc.1" must publish under a dist-tag other
         # than npm's default "latest" - otherwise a plain `npm install
         # @wpmoo/ui` would resolve to a release candidate instead of the
-        # last stable release the moment an RC tag is pushed.
-        self.assertIn('if [[ "${version}" == *-* ]]; then', workflow)
-        self.assertIn('echo "npm_tag=rc" >> "$GITHUB_OUTPUT"', workflow)
-        self.assertIn('echo "npm_tag=latest" >> "$GITHUB_OUTPUT"', workflow)
+        # last stable release the moment an RC tag is pushed. Split on the
+        # if/else/fi markers so each output pair is checked inside its own
+        # branch, not just present somewhere in the file - a swapped
+        # npm_tag/prerelease pair between branches would otherwise still
+        # pass a plain assertIn check.
+        marker = 'if [[ "${version}" == *-* ]]; then'
+        self.assertIn(marker, workflow)
+        _, _, after_if = workflow.partition(marker)
+        prerelease_branch, has_else, after_else = after_if.partition("\n          else\n")
+        self.assertTrue(has_else, "expected an else branch immediately after the if")
+        stable_branch, has_fi, _ = after_else.partition("\n          fi\n")
+        self.assertTrue(has_fi, "expected a closing fi for the version-check if")
+
+        self.assertIn('echo "npm_tag=rc" >> "$GITHUB_OUTPUT"', prerelease_branch)
+        self.assertIn('echo "prerelease=true" >> "$GITHUB_OUTPUT"', prerelease_branch)
+        self.assertIn('echo "npm_tag=latest" >> "$GITHUB_OUTPUT"', stable_branch)
+        self.assertIn('echo "prerelease=false" >> "$GITHUB_OUTPUT"', stable_branch)
+        self.assertNotIn("npm_tag=latest", prerelease_branch)
+        self.assertNotIn("npm_tag=rc", stable_branch)
+
         self.assertIn(
             'npm publish --access public --provenance --tag '
             '"${{ steps.package.outputs.npm_tag }}"',
@@ -541,7 +557,6 @@ for (const specifier of [
         self.assertNotIn("npm publish --access public --provenance\n", workflow)
         # The GitHub release itself must also be marked prerelease, not
         # presented as a normal stable release.
-        self.assertIn('echo "prerelease=true" >> "$GITHUB_OUTPUT"', workflow)
         self.assertIn(
             'if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then',
             workflow,

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -521,6 +521,33 @@ for (const specifier of [
             workflow,
         )
 
+    def test_publish_workflow_never_tags_a_prerelease_as_npm_latest(self) -> None:
+        workflow = (ROOT / ".github/workflows/npm-publish.yml").read_text(
+            encoding="utf-8"
+        )
+
+        # A version like "1.0.0-rc.1" must publish under a dist-tag other
+        # than npm's default "latest" - otherwise a plain `npm install
+        # @wpmoo/ui` would resolve to a release candidate instead of the
+        # last stable release the moment an RC tag is pushed.
+        self.assertIn('if [[ "${version}" == *-* ]]; then', workflow)
+        self.assertIn('echo "npm_tag=rc" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn('echo "npm_tag=latest" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn(
+            'npm publish --access public --provenance --tag '
+            '"${{ steps.package.outputs.npm_tag }}"',
+            workflow,
+        )
+        self.assertNotIn("npm publish --access public --provenance\n", workflow)
+        # The GitHub release itself must also be marked prerelease, not
+        # presented as a normal stable release.
+        self.assertIn('echo "prerelease=true" >> "$GITHUB_OUTPUT"', workflow)
+        self.assertIn(
+            'if [ "${{ steps.package.outputs.prerelease }}" = "true" ]; then',
+            workflow,
+        )
+        self.assertIn("release_args+=(--prerelease)", workflow)
+
     def test_release_tag_workflow_creates_lightweight_tags(self) -> None:
         workflow = (ROOT / ".github/workflows/release-tag.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
Publishing 1.0.0-rc.1 with the workflow as it stood would run bare
`npm publish --access public --provenance` with no `--tag`, which defaults
to npm's "latest" dist-tag regardless of the version string - every plain
`npm install @wpmoo/ui` would suddenly resolve to a release candidate
instead of the last stable release the moment the RC tag pushed. Found
while preparing to actually cut 1.0.0-rc.1, before it happened.

The version-check step now derives `npm_tag` (`rc` for anything with a
`-` in the version, `latest` otherwise) and `prerelease` (true/false)
alongside its existing outputs; the publish step passes `--tag`
explicitly, and the release-notes step adds `--prerelease` so the GitHub
Release is marked as one instead of presenting a release candidate as a
normal stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Package publishing now applies the correct npm tag for stable and prerelease versions.
  * GitHub releases for prerelease versions are now correctly marked as prereleases.

* **Tests**
  * Added coverage verifying npm tags and GitHub release settings for stable and prerelease packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->