### PR TITLE
ci: raise npm-publish job timeout from 10 to 25 minutes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,7 +23,12 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Same root cause as ui-ci.yml's ui-tests job: this workflow runs the same
+    # full suite ("Run contract tests") on a cold ubuntu-latest runner, and the
+    # old 10-minute budget was cancelling it mid-suite before publish ever ran
+    # (observed on the v1.0.0-rc.2 tag run: cancelled at "Run contract tests",
+    # every step after it skipped, including "Publish to npm").
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
The v1.0.0-rc.2 tag push triggered `npm-publish.yml`, which got cancelled mid "Run contract tests" — the same 10-minute job timeout that `ui-ci.yml`'s `ui-tests` job just hit (fixed in the previous PR). Every step after the test run, including **"Publish to npm" and the GitHub Release, was skipped**. The `v1.0.0-rc.2` tag exists but the package was never actually published.

## Fix
Raise `timeout-minutes` from 10 to 25 in `npm-publish.yml`'s `publish` job, matching the fix already applied to `ui-ci.yml`.

## Next step after merge
Manually dispatch `npm-publish.yml` with `release_ref: v1.0.0-rc.2` to publish from the existing tag without recreating it (documented recovery path for this exact workflow input).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the npm publishing workflow timeout to improve reliability when contract tests take longer to complete.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->