### PR TITLE
feat(settings): add Direction and Sidebar pickers to global settings panel

### DIFF
--- a/site/scss/catalog/_docs.scss
+++ b/site/scss/catalog/_docs.scss
@@ -811,3 +811,21 @@
   height: 0.875rem;
   color: var(--bs-secondary-color);
 }
+
+// The LTR/RTL picker is a joined segmented control; the checked option gets
+// the same muted-surface treatment as the theme picker's active state.
+.moo-settings-panel__direction-option {
+  justify-content: center;
+  gap: 0.375rem;
+}
+
+.moo-settings-panel__direction-option [data-icon] {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.moo-settings-panel__direction-group .btn-check:checked + .moo-settings-panel__direction-option {
+  border-color: var(--moo-border);
+  color: var(--bs-body-color);
+  background-color: var(--moo-muted-surface);
+}

--- a/site/scss/catalog/_docs.scss
+++ b/site/scss/catalog/_docs.scss
@@ -728,6 +728,14 @@
   display: inline-flex;
 }
 
+// The check straddles the inline-end corner, and the +50% translate is
+// physical -- in RTL the corner is on the left, so the same transform would
+// push it toward the top-center. Flip the X translate to keep it on the
+// corner.
+[dir="rtl"] .moo-settings-panel__theme-check {
+  transform: translate(-50%, -50%);
+}
+
 .moo-settings-panel__theme-thumb {
   position: relative;
   display: block;
@@ -812,20 +820,41 @@
   color: var(--bs-secondary-color);
 }
 
-// The LTR/RTL picker is a joined segmented control; the checked option gets
-// the same muted-surface treatment as the theme picker's active state.
-.moo-settings-panel__direction-option {
-  justify-content: center;
-  gap: 0.375rem;
+// The direction picker reuses the theme picker's image-option pattern
+// (thumbnail + corner check + muted unselected). The thumbnail is a neutral
+// window mock whose bar carries a direction arrow and whose lines align to
+// the reading start; the alignment is physical (not logical) so each preview
+// keeps its own direction regardless of the page's current dir.
+.moo-settings-panel__direction-thumb {
+  background: var(--bs-secondary-bg);
 }
 
-.moo-settings-panel__direction-option [data-icon] {
-  width: 0.875rem;
-  height: 0.875rem;
+.moo-settings-panel__direction-thumb .moo-settings-panel__theme-thumb-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding-inline: 0.1875rem;
+  background: color-mix(in srgb, var(--bs-border-color) 55%, transparent);
 }
 
-.moo-settings-panel__direction-group .btn-check:checked + .moo-settings-panel__direction-option {
-  border-color: var(--moo-border);
-  color: var(--bs-body-color);
-  background-color: var(--moo-muted-surface);
+.moo-settings-panel__direction-thumb .moo-settings-panel__theme-thumb-bar [data-icon] {
+  width: 0.5rem;
+  height: 0.5rem;
+  color: var(--bs-secondary-color);
+}
+
+.moo-settings-panel__direction-thumb .moo-settings-panel__theme-thumb-line {
+  background: var(--bs-border-color);
+}
+
+.moo-settings-panel__direction-thumb--rtl .moo-settings-panel__theme-thumb-bar {
+  justify-content: flex-end;
+}
+
+.moo-settings-panel__direction-thumb--ltr .moo-settings-panel__theme-thumb-line {
+  margin-right: auto;
+}
+
+.moo-settings-panel__direction-thumb--rtl .moo-settings-panel__theme-thumb-line {
+  margin-left: auto;
 }

--- a/site/scss/catalog/_docs.scss
+++ b/site/scss/catalog/_docs.scss
@@ -858,3 +858,96 @@
 .moo-settings-panel__direction-thumb--rtl .moo-settings-panel__theme-thumb-line {
   margin-left: auto;
 }
+
+// The Sidebar picker's window mock mirrors the real catalog layout: a
+// sidebar column on the left (light secondary bg) and a content column on
+// the right (top bar + content lines, same visual language as the theme
+// and direction thumbnails). The three variants differ in how the sidebar
+// and content relate:
+// - sidebar: flush, border between sidebar and content
+// - inset: content is a floating card with gap, rounded corners, shadow
+// - floating: sidebar is a detached card with its own gap/radius/shadow
+.moo-settings-panel__sidebar-thumb {
+  display: flex;
+  background: var(--bs-body-bg);
+}
+
+.moo-settings-panel__sidebar-thumb-rail {
+  flex: 0 0 auto;
+  width: 28%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.375rem 0.25rem;
+  background: var(--bs-secondary-bg);
+  border-inline-end: var(--bs-border-width) solid var(--bs-border-color);
+}
+
+.moo-settings-panel__sidebar-thumb-nav {
+  display: block;
+  height: 0.1875rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bs-body-color) 28%, transparent);
+}
+
+.moo-settings-panel__sidebar-thumb-nav.is-wide {
+  width: 100%;
+}
+
+.moo-settings-panel__sidebar-thumb-nav.is-short {
+  width: 65%;
+}
+
+.moo-settings-panel__sidebar-thumb-nav.is-tiny {
+  width: 45%;
+}
+
+.moo-settings-panel__sidebar-thumb-panel {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  padding-block-start: 0.25rem;
+}
+
+// The content area's skeleton lines are muted so the sidebar stays the
+// focal point -- no header bar, just a couple of faint paragraph-like lines.
+.moo-settings-panel__sidebar-thumb-panel .moo-settings-panel__theme-thumb-bar {
+  display: none;
+}
+
+.moo-settings-panel__sidebar-thumb-panel .moo-settings-panel__theme-thumb-line {
+  background: color-mix(in srgb, var(--bs-border-color) 25%, transparent);
+}
+
+// Inset: the whole background is the sidebar's secondary bg; only the
+// content panel lifts into a body-bg card with gap, rounded corners, and
+// shadow -- the sidebar's border goes away, the separation is the gap.
+.moo-settings-panel__sidebar-thumb--inset {
+  background: var(--bs-secondary-bg);
+}
+
+.moo-settings-panel__sidebar-thumb--inset .moo-settings-panel__sidebar-thumb-rail {
+  border-inline-end: 0;
+  background: transparent;
+}
+
+.moo-settings-panel__sidebar-thumb--inset .moo-settings-panel__sidebar-thumb-panel {
+  margin: 0.25rem;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius-sm);
+  box-shadow: var(--bs-box-shadow-sm);
+  background: var(--bs-body-bg);
+  overflow: hidden;
+}
+
+// Floating: the sidebar becomes a detached card -- its own margin, radius,
+// shadow, and secondary bg -- while the content area stays flush.
+.moo-settings-panel__sidebar-thumb--floating .moo-settings-panel__sidebar-thumb-rail {
+  margin: 0.25rem;
+  padding: 0.25rem;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius-sm);
+  border-inline-end: 0;
+  background: var(--bs-secondary-bg);
+  box-shadow: var(--bs-box-shadow-sm);
+}

--- a/site/scss/catalog/_shell.scss
+++ b/site/scss/catalog/_shell.scss
@@ -168,6 +168,32 @@ body {
   overflow: hidden;
 }
 
+// Inset variant: the content card is rounded but doesn't clip its children
+// (the main scrolls), so the direct children that reach the card's corners
+// -- the top bar and the trailing footer/main -- get the same radius,
+// otherwise square corners poke past the card's rounded ones.
+.sidebar-wrapper:has(.sidebar[data-variant="inset"]) .moo-catalog__header {
+  border-top-left-radius: var(--bs-border-radius-xl);
+  border-top-right-radius: var(--bs-border-radius-xl);
+}
+
+.sidebar-wrapper:has(.sidebar[data-variant="inset"]) .moo-catalog__main:last-child,
+.sidebar-wrapper:has(.sidebar[data-variant="inset"]) .moo-catalog__footer:last-child {
+  border-bottom-left-radius: var(--bs-border-radius-xl);
+  border-bottom-right-radius: var(--bs-border-radius-xl);
+}
+
+// Inset: the content card floats with a gap on every side instead of
+// touching the sidebar, and the sidebar's edge border goes away -- the
+// separation between the page and the card is the gap, not a border.
+.sidebar-wrapper:has(.sidebar[data-variant="inset"]) .sidebar-inset {
+  margin-inline-start: 0.5rem;
+}
+
+.sidebar-wrapper:has(.sidebar[data-variant="inset"]) .sidebar-inner {
+  border-inline-end: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .moo-catalog .sidebar {
     transition: none;

--- a/site/src/includes/settings-panel.html.jinja
+++ b/site/src/includes/settings-panel.html.jinja
@@ -45,6 +45,26 @@
         {% endfor %}
       </div>
 
+      <div>
+        {{ typography("Direction", variant="section-title") }}
+        <p class="text-body-secondary small mb-0">
+          Choose the reading direction. RTL flips the layout live.
+        </p>
+      </div>
+
+      <div class="btn-group btn-group-sm moo-settings-panel__direction-group w-100" role="radiogroup" aria-label="Direction">
+        <input type="radio" class="btn-check" name="moo-settings-direction" value="ltr" id="moo-settings-direction-ltr" data-moo-settings-direction autocomplete="off">
+        <label class="btn btn-outline-secondary moo-settings-panel__direction-option" for="moo-settings-direction-ltr">
+          {{ render_icon("arrow-left-to-line", "inline-start") }}
+          LTR
+        </label>
+        <input type="radio" class="btn-check" name="moo-settings-direction" value="rtl" id="moo-settings-direction-rtl" data-moo-settings-direction autocomplete="off">
+        <label class="btn btn-outline-secondary moo-settings-panel__direction-option" for="moo-settings-direction-rtl">
+          {{ render_icon("arrow-right-to-line", "inline-start") }}
+          RTL
+        </label>
+      </div>
+
       {{ separator() }}
 
       <div class="d-flex justify-content-between align-items-center gap-3">

--- a/site/src/includes/settings-panel.html.jinja
+++ b/site/src/includes/settings-panel.html.jinja
@@ -52,17 +52,25 @@
         </p>
       </div>
 
-      <div class="btn-group btn-group-sm moo-settings-panel__direction-group w-100" role="radiogroup" aria-label="Direction">
-        <input type="radio" class="btn-check" name="moo-settings-direction" value="ltr" id="moo-settings-direction-ltr" data-moo-settings-direction autocomplete="off">
-        <label class="btn btn-outline-secondary moo-settings-panel__direction-option" for="moo-settings-direction-ltr">
-          {{ render_icon("arrow-left-to-line", "inline-start") }}
-          LTR
-        </label>
-        <input type="radio" class="btn-check" name="moo-settings-direction" value="rtl" id="moo-settings-direction-rtl" data-moo-settings-direction autocomplete="off">
-        <label class="btn btn-outline-secondary moo-settings-panel__direction-option" for="moo-settings-direction-rtl">
-          {{ render_icon("arrow-right-to-line", "inline-start") }}
-          RTL
-        </label>
+      <div class="moo-settings-panel__theme-group" role="radiogroup" aria-label="Direction">
+        {% for option in [
+          {"value": "ltr", "label": "LTR", "icon": "arrow-left-to-line"},
+          {"value": "rtl", "label": "RTL", "icon": "arrow-right-to-line"}
+        ] %}
+          <label class="moo-settings-panel__theme-option">
+            <input type="radio" class="btn-check" name="moo-settings-direction" value="{{ option.value }}" data-moo-settings-direction autocomplete="off">
+            <span class="moo-settings-panel__theme-check" aria-hidden="true">{{ render_icon("check", "inline-start") }}</span>
+            <span class="moo-settings-panel__theme-thumb moo-settings-panel__direction-thumb moo-settings-panel__direction-thumb--{{ option.value }}" aria-hidden="true">
+              <span class="moo-settings-panel__theme-thumb-bar">{{ render_icon(option.icon, "inline-end") }}</span>
+              <span class="moo-settings-panel__theme-thumb-body">
+                <span class="moo-settings-panel__theme-thumb-line"></span>
+                <span class="moo-settings-panel__theme-thumb-line is-short"></span>
+                <span class="moo-settings-panel__theme-thumb-line is-tiny"></span>
+              </span>
+            </span>
+            <span class="moo-settings-panel__theme-label">{{ option.label }}</span>
+          </label>
+        {% endfor %}
       </div>
 
       {{ separator() }}

--- a/site/src/includes/settings-panel.html.jinja
+++ b/site/src/includes/settings-panel.html.jinja
@@ -46,6 +46,45 @@
       </div>
 
       <div>
+        {{ typography("Sidebar", variant="section-title") }}
+        <p class="text-body-secondary small mb-0">
+          Choose how the sidebar sits on the page.
+        </p>
+      </div>
+
+      <div class="moo-settings-panel__theme-group" role="radiogroup" aria-label="Sidebar">
+        {% for option in [
+          {"value": "sidebar", "label": "Sidebar", "icon": "panel-left"},
+          {"value": "inset", "label": "Inset", "icon": "panel-left"},
+          {"value": "floating", "label": "Floating", "icon": "panel-left"}
+        ] %}
+          <label class="moo-settings-panel__theme-option">
+            <input type="radio" class="btn-check" name="moo-settings-sidebar" value="{{ option.value }}" data-moo-settings-sidebar autocomplete="off">
+            <span class="moo-settings-panel__theme-check" aria-hidden="true">{{ render_icon("check", "inline-start") }}</span>
+            <span class="moo-settings-panel__theme-thumb moo-settings-panel__sidebar-thumb moo-settings-panel__sidebar-thumb--{{ option.value }}" aria-hidden="true">
+              <span class="moo-settings-panel__sidebar-thumb-rail">
+                <span class="moo-settings-panel__sidebar-thumb-nav is-wide"></span>
+                <span class="moo-settings-panel__sidebar-thumb-nav"></span>
+                <span class="moo-settings-panel__sidebar-thumb-nav is-short"></span>
+                <span class="moo-settings-panel__sidebar-thumb-nav is-tiny"></span>
+              </span>
+              <span class="moo-settings-panel__sidebar-thumb-panel">
+                <span class="moo-settings-panel__theme-thumb-bar"></span>
+                <span class="moo-settings-panel__theme-thumb-body">
+                  <span class="moo-settings-panel__theme-thumb-line"></span>
+                  <span class="moo-settings-panel__theme-thumb-line is-short"></span>
+                </span>
+              </span>
+            </span>
+            <span class="moo-settings-panel__theme-label">
+              {{ render_icon(option.icon, "inline-start") }}
+              {{ option.label }}
+            </span>
+          </label>
+        {% endfor %}
+      </div>
+
+      <div>
         {{ typography("Direction", variant="section-title") }}
         <p class="text-body-secondary small mb-0">
           Choose the reading direction. RTL flips the layout live.

--- a/site/src/js/catalog/settings-panel.js
+++ b/site/src/js/catalog/settings-panel.js
@@ -1,6 +1,7 @@
 const states = new WeakMap();
 const THEME_STORAGE_KEY = "moo:theme";
 const DIRECTION_STORAGE_KEY = "moo:direction";
+const SIDEBAR_STORAGE_KEY = "moo:sidebar-variant";
 
 function effectiveTheme(preference, view) {
   if (preference === "system") {
@@ -31,6 +32,9 @@ export function initSettingsPanel(root = document) {
     );
     const directionInputs = Array.from(
       sheet.querySelectorAll("[data-moo-settings-direction]")
+    );
+    const sidebarInputs = Array.from(
+      sheet.querySelectorAll("[data-moo-settings-sidebar]")
     );
     const reset = sheet.querySelector("[data-moo-settings-reset]");
     const listen = (target, type, handler) => {
@@ -123,10 +127,46 @@ export function initSettingsPanel(root = document) {
       });
     });
 
+    // Phase 8: the Sidebar picker switches the catalog layout's data-variant
+    // live (the sidebar SCSS keys off it) and persists the choice.
+    const sidebar = root.querySelector("#catalog-sidebar");
+    const readSidebarVariant = () => {
+      try {
+        const stored = view.localStorage.getItem(SIDEBAR_STORAGE_KEY);
+        if (stored === "sidebar" || stored === "inset" || stored === "floating") {
+          return stored;
+        }
+      } catch (_) {
+        /* Storage can be unavailable in restricted browsing contexts. */
+      }
+      return "sidebar";
+    };
+    const applySidebarVariant = (variant) => {
+      if (sidebar) {
+        sidebar.dataset.variant = variant;
+      }
+      try {
+        view.localStorage.setItem(SIDEBAR_STORAGE_KEY, variant);
+      } catch (_) {
+        /* Storage is best-effort. */
+      }
+      sidebarInputs.forEach((input) => {
+        input.checked = input.value === variant;
+      });
+    };
+    sidebarInputs.forEach((input) => {
+      listen(input, "change", () => {
+        if (input.checked) {
+          applySidebarVariant(input.value);
+        }
+      });
+    });
+
     listen(reset, "click", () => {
       try {
         view.localStorage.removeItem(THEME_STORAGE_KEY);
         view.localStorage.removeItem(DIRECTION_STORAGE_KEY);
+        view.localStorage.removeItem(SIDEBAR_STORAGE_KEY);
       } catch (_) {
         /* Storage is best-effort. */
       }
@@ -137,6 +177,12 @@ export function initSettingsPanel(root = document) {
       });
       directionInputs.forEach((input) => {
         input.checked = input.value === "ltr";
+      });
+      if (sidebar) {
+        sidebar.dataset.variant = "sidebar";
+      }
+      sidebarInputs.forEach((input) => {
+        input.checked = input.value === "sidebar";
       });
       syncThemeButton();
     });
@@ -151,6 +197,10 @@ export function initSettingsPanel(root = document) {
       const direction = readDirection();
       directionInputs.forEach((input) => {
         input.checked = input.value === direction;
+      });
+      const sidebarVariant = readSidebarVariant();
+      sidebarInputs.forEach((input) => {
+        input.checked = input.value === sidebarVariant;
       });
     });
   }

--- a/site/src/js/catalog/settings-panel.js
+++ b/site/src/js/catalog/settings-panel.js
@@ -1,5 +1,6 @@
 const states = new WeakMap();
 const THEME_STORAGE_KEY = "moo:theme";
+const DIRECTION_STORAGE_KEY = "moo:direction";
 
 function effectiveTheme(preference, view) {
   if (preference === "system") {
@@ -27,6 +28,9 @@ export function initSettingsPanel(root = document) {
     const view = root.defaultView || root.ownerDocument?.defaultView;
     const themeInputs = Array.from(
       sheet.querySelectorAll("[data-moo-settings-theme]")
+    );
+    const directionInputs = Array.from(
+      sheet.querySelectorAll("[data-moo-settings-direction]")
     );
     const reset = sheet.querySelector("[data-moo-settings-reset]");
     const listen = (target, type, handler) => {
@@ -87,25 +91,66 @@ export function initSettingsPanel(root = document) {
       });
     });
 
+    // Phase 7: the LTR/RTL picker flips the document direction live and
+    // persists it under moo:direction so it survives navigation.
+    const readDirection = () => {
+      try {
+        const stored = view.localStorage.getItem(DIRECTION_STORAGE_KEY);
+        if (stored === "ltr" || stored === "rtl") {
+          return stored;
+        }
+      } catch (_) {
+        /* Storage can be unavailable in restricted browsing contexts. */
+      }
+      return "ltr";
+    };
+    const applyDirection = (direction) => {
+      documentElement.dir = direction;
+      try {
+        view.localStorage.setItem(DIRECTION_STORAGE_KEY, direction);
+      } catch (_) {
+        /* Storage is best-effort. */
+      }
+      directionInputs.forEach((input) => {
+        input.checked = input.value === direction;
+      });
+    };
+    directionInputs.forEach((input) => {
+      listen(input, "change", () => {
+        if (input.checked) {
+          applyDirection(input.value);
+        }
+      });
+    });
+
     listen(reset, "click", () => {
       try {
         view.localStorage.removeItem(THEME_STORAGE_KEY);
+        view.localStorage.removeItem(DIRECTION_STORAGE_KEY);
       } catch (_) {
         /* Storage is best-effort. */
       }
       documentElement.dataset.bsTheme = effectiveTheme("system", view);
+      documentElement.dir = "ltr";
       themeInputs.forEach((input) => {
         input.checked = input.value === "system";
+      });
+      directionInputs.forEach((input) => {
+        input.checked = input.value === "ltr";
       });
       syncThemeButton();
     });
 
-    // Reflect the current preference whenever the sheet opens, so a choice
-    // made through the navbar toggle shows up here too.
+    // Reflect the current preferences whenever the sheet opens, so choices
+    // made through the navbar toggle show up here too.
     listen(sheet, "show.bs.offcanvas", () => {
       const preference = readPreference();
       themeInputs.forEach((input) => {
         input.checked = input.value === preference;
+      });
+      const direction = readDirection();
+      directionInputs.forEach((input) => {
+        input.checked = input.value === direction;
       });
     });
   }

--- a/site/src/js/catalog/theme.js
+++ b/site/src/js/catalog/theme.js
@@ -22,9 +22,6 @@ export function initTheme(root = document) {
   const themeButton = root.querySelector(
     "[data-moo-theme], .moo-catalog__theme-toggle"
   );
-  const directionButton = root.querySelector(
-    "[data-moo-direction], .moo-catalog__direction-toggle"
-  );
   const themeIcons = Array.from(
     themeButton?.querySelectorAll("[data-moo-theme-icon]") || []
   );
@@ -89,12 +86,6 @@ export function initTheme(root = document) {
       /* Storage is best-effort. */
     }
     updateThemeButton();
-  });
-
-  listen(directionButton, "click", () => {
-    const direction = documentElement.dir === "rtl" ? "ltr" : "rtl";
-    documentElement.dir = direction;
-    directionButton.textContent = direction === "rtl" ? "LTR" : "RTL";
   });
 
   updateThemeButton();

--- a/site/src/layouts/base.html.jinja
+++ b/site/src/layouts/base.html.jinja
@@ -38,6 +38,16 @@
             window.matchMedia("(prefers-color-scheme: dark)").matches;
           document.documentElement.dataset.bsTheme = dark ? "dark" : "light";
         }
+        // Phase 7: restore a saved reading direction before first paint so an
+        // RTL choice never flashes back to LTR.
+        try {
+          const storedDirection = window.localStorage.getItem("moo:direction");
+          if (storedDirection === "rtl") {
+            document.documentElement.dir = "rtl";
+          }
+        } catch (_) {
+          /* Storage can be unavailable in restricted browsing contexts. */
+        }
         try {
           const sidebar = window.localStorage.getItem("moo-sidebar:catalog-shell");
           if (sidebar === "collapsed" || sidebar === "expanded") {

--- a/site/src/layouts/catalog.html.jinja
+++ b/site/src/layouts/catalog.html.jinja
@@ -18,6 +18,24 @@
         })();
       </script>
       {% include "shell/sidebar.html.jinja" %}
+      <script>
+        (() => {
+          // Apply a saved Sidebar variant synchronously, right after the
+          // sidebar renders and before the rest of the page paints, so a
+          // non-default choice never flashes the default layout first.
+          var sidebar = document.getElementById("catalog-sidebar");
+          if (!sidebar) return;
+          var stored;
+          try {
+            stored = window.localStorage.getItem("moo:sidebar-variant");
+          } catch (_) {
+            return;
+          }
+          if (stored === "sidebar" || stored === "inset" || stored === "floating") {
+            sidebar.dataset.variant = stored;
+          }
+        })();
+      </script>
       {% call sidebar_inset() %}
         {% include "shell/navbar.html.jinja" %}
         <main class="moo-catalog__main sidebar-inset__content scroll-fade-y no-scrollbar" id="main-content" tabindex="-1">


### PR DESCRIPTION
## Summary

Phases 7 and 8 of the post-1.0 admin demo showcase plan: global settings panel now supports Direction (LTR/RTL) and Sidebar variant (sidebar/inset/floating) pickers, completing the three-stage settings panel (Theme → Direction → Sidebar).

## Changes

### Phase 7 — Direction (LTR/RTL) picker
- Image-toggle thumbnails matching the Appearance picker visual language
- Arrow icons in the thumbnail bar indicate reading direction
- Live direction switching via `dir` attribute, persisted under `moo:direction`
- Synchronous restore script prevents flash of wrong direction

### Phase 8 — Sidebar variant picker
- Three variants: sidebar (flush), inset (floating content card), floating (detached sidebar card)
- Thumbnails mirror the real catalog layout — secondary-bg sidebar column with nav lines, body-bg content area with faint paragraph skeleton
- Live variant switching via `data-variant` attribute, persisted under `moo:sidebar-variant`
- Synchronous restore script prevents flash of default layout

## Verification

- Full test suite: 863 tests OK (skipped=1)
- Browser-verified across light/dark/RTL/responsive
- Preference persistence verified across navigation
- No new Moo UI components — all site-only changes under `site/`
- CSS in `site/scss/catalog/` (demo-local, not shipped)
- Reset clears all three preferences (theme, direction, sidebar)

## Plan compliance

- No new Moo UI components
- No package source changes (`src/`, `package.json` unchanged)
- No push/tag/publish — this PR is the expected path to `main`
- Static fixture data, no backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings to switch between left-to-right and right-to-left reading direction.
  * Added sidebar layout options: standard, inset, and floating, with visual previews.
  * Preferences are saved and restored automatically across visits.
  * Added styling for RTL layouts, sidebar variants, and directional previews.

* **Bug Fixes**
  * Prevented layout preferences from visibly changing after the page first loads.
  * Added safe handling when saved preferences are unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->